### PR TITLE
API Key Authentication

### DIFF
--- a/dataregistry/api/api.py
+++ b/dataregistry/api/api.py
@@ -3,17 +3,30 @@ import sqlalchemy
 from botocore.exceptions import ClientError
 
 from dataregistry.api import query
-from dataregistry.api.db import DataRegistryReadWriteDB
+from dataregistry.api.config import APP_CONFIG
+from dataregistry.api.db import DataRegistryReadWriteDB, DataRegistryDB
 from dataregistry.api.model import RecordRequest
+from fastapi.security.api_key import APIKeyHeader
+from starlette.status import HTTP_403_FORBIDDEN
 
-# create flask app; this will load .env
 router = fastapi.APIRouter()
 
 # connect to database
 engine = DataRegistryReadWriteDB().get_engine()
+api_key_header = APIKeyHeader(name="access_token", auto_error=False)
+valid_api_key = APP_CONFIG['apiKey']
 
 
-@router.get('/records', response_class=fastapi.responses.ORJSONResponse)
+async def get_api_key(request_api_key: str = fastapi.Security(api_key_header)):
+    if request_api_key == valid_api_key:
+        return api_key_header
+    else:
+        raise fastapi.HTTPException(
+            status_code=HTTP_403_FORBIDDEN, detail="Could not validate API KEY"
+        )
+
+
+@router.get('/records', response_class=fastapi.responses.ORJSONResponse, dependencies=[fastapi.Depends(get_api_key)])
 async def api_records():
     try:
         records = query.get_all_records(engine)
@@ -22,7 +35,7 @@ async def api_records():
         raise fastapi.HTTPException(status_code=400, detail=str(e))
 
 
-@router.get('/records/{index}', response_class=fastapi.responses.ORJSONResponse)
+@router.get('/records/{index}', response_class=fastapi.responses.ORJSONResponse, dependencies=[fastapi.Depends(get_api_key)])
 async def api_records(index: int):
     try:
         record = query.get_record(engine, index)
@@ -33,7 +46,7 @@ async def api_records(index: int):
         raise fastapi.HTTPException(status_code=400, detail=str(e))
 
 
-@router.post('/records', response_class=fastapi.responses.ORJSONResponse)
+@router.post('/records', response_class=fastapi.responses.ORJSONResponse, dependencies=[fastapi.Depends(get_api_key)])
 async def api_record_post(req: RecordRequest):
     """
     The body of the request contains the information to insert into the records db
@@ -51,7 +64,7 @@ async def api_record_post(req: RecordRequest):
         raise fastapi.HTTPException(status_code=400, detail=str(e))
 
 
-@router.delete('/records/{index}', response_class=fastapi.responses.ORJSONResponse)
+@router.delete('/records/{index}', response_class=fastapi.responses.ORJSONResponse, dependencies=[fastapi.Depends(get_api_key)])
 async def api_record_delete(index: int):
     """
     Soft delete both the database (by setting the `deleted` field to the current timestamp)

--- a/dataregistry/api/config.py
+++ b/dataregistry/api/config.py
@@ -1,0 +1,11 @@
+import json
+
+from boto3 import Session
+
+
+def get_sensitive_config():
+    client = Session().client('secretsmanager', region_name='us-east-1')
+    return json.loads(client.get_secret_value(SecretId='data-registry')['SecretString'])
+
+
+APP_CONFIG = get_sensitive_config()

--- a/dataregistry/api/db.py
+++ b/dataregistry/api/db.py
@@ -4,6 +4,8 @@ from boto3.session import Session
 import json
 import sqlalchemy
 
+from dataregistry.api.config import APP_CONFIG
+
 
 class DataRegistryDB:
     def __init__(self, username_field, password_field):
@@ -14,18 +16,12 @@ class DataRegistryDB:
         self.config = None
         self.url = None
 
-    def get_config(self):
-        if self.config is None:
-            client = Session().client('secretsmanager', region_name=self.region)
-            self.config = json.loads(client.get_secret_value(SecretId=self.secret_id)['SecretString'])
-        return self.config
-
     def get_url(self):
         if self.url is None:
             if os.getenv('DATA_REGISTRY_DB_CONNECTION'):
                 self.url = os.getenv('DATA_REGISTRY_DB_CONNECTION')
             else:
-                self.config = self.get_config()
+                self.config = APP_CONFIG
                 self.url = '{engine}://{username}:{password}@{host}:{port}/{db}'.format(
                     engine=self.config['engine'] + ('+pymysql' if self.config['engine'] == 'mysql' else ''),
                     username=self.config[self.username_field],

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sqlalchemy
 uvicorn
 alembic
 pydantic
+cryptography


### PR DESCRIPTION
Before I started making calls to s3 storage, I wanted to introduce a little bit of security.  This code change makes it so a request header called `access_token` containing a valid value is now required for any end points to proceed with processing.  There's currently one valid value for that header and it lives in the AWS secret for this project under the key `apiKey`.  This is likely a temporary solution for authentication.