### PR TITLE
Tests and improvements for upload to s3 

### DIFF
--- a/dataregistry/api/api.py
+++ b/dataregistry/api/api.py
@@ -38,7 +38,8 @@ async def api_records(index: int):
 
 
 @router.post("/uploadfile/{data_type}/{phenotype}/{record_name}/{record_id}")
-async def upload_file_for_record(data_type: str, phenotype: str, record_name: str, record_id: int, file: UploadFile):
+async def upload_file_for_record(data_type: str, phenotype: str, record_name: str, record_id: int, file: UploadFile,
+                                 response: fastapi.Response):
     try:
         file_path = f"{data_type}/{record_name}/{phenotype}"
         upload = s3.initiate_multi_part(file_path, file.filename)
@@ -56,6 +57,7 @@ async def upload_file_for_record(data_type: str, phenotype: str, record_name: st
         query.insert_data_set(engine, record_id, record_name, phenotype, data_type, file.filename)
     except Exception as e:
         logger.exception("There was a problem uploading file", e)
+        response.status_code = 400
         return {"message": "There was an error uploading the file"}
     finally:
         await file.close()

--- a/dataregistry/api/query.py
+++ b/dataregistry/api/query.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import re
 
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from dataregistry.api import s3
@@ -68,15 +69,14 @@ def insert_record(engine, data: Record):
     return s3_record_id
 
 
-def insert_data_set(engine, record_id: int, s3_bucket_id: str, description: str, data_type: str, name: str):
-    session = Session(engine)
-    with session.begin():
-        sql_params = {'record_id': record_id, 's3_bucket_id': s3_bucket_id, 'description': description,
+def insert_data_set(engine, record_id: int, s3_bucket_id: str, phenotype: str, data_type: str, name: str):
+    with engine.connect() as conn:
+        sql_params = {'record_id': record_id, 's3_bucket_id': s3_bucket_id, 'phenotype': phenotype,
                       'data_type': data_type, 'name': name}
-        session.execute("""
-            INSERT INTO datasets (record_id, s3_bucket_id, name, description, data_type) 
-            VALUES(:record_id, :s3_bucket_id, :name, :description, :data_type)
-        """, sql_params)
+        conn.execute(text("""
+            INSERT INTO datasets (record_id, s3_bucket_id, name, phenotype, data_type) 
+            VALUES(:record_id, :s3_bucket_id, :name, :phenotype, :data_type)
+        """), **sql_params)
 
 
 def delete_record(engine, index):

--- a/migrations/versions/2023_02_16_1925-aaa800cb0c9c_change_datasets_description_to_phenotype.py
+++ b/migrations/versions/2023_02_16_1925-aaa800cb0c9c_change_datasets_description_to_phenotype.py
@@ -1,0 +1,27 @@
+"""change datasets description to phenotype
+
+Revision ID: aaa800cb0c9c
+Revises: d1031a6d0f48
+Create Date: 2023-02-16 19:25:16.145003
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = 'aaa800cb0c9c'
+down_revision = 'd1031a6d0f48'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(text("ALTER TABLE datasets rename column description to phenotype"))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(text("ALTER TABLE datasets rename column phenotype to description"))

--- a/tests/sample_upload.txt
+++ b/tests/sample_upload.txt
@@ -1,0 +1,1 @@
+The answer is 47!

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,6 +89,25 @@ def test_post_then_retrieve_by_id(api_client: TestClient):
     assert response.status_code == HTTP_200_OK
 
 
+@mock_s3
+def test_upload_file(api_client: TestClient):
+    set_up_moto_bucket()
+    new_record = example_json.copy()
+    record_name = 'file_upload_test'
+    new_record['name'] = record_name
+    api_client.post(api_path,
+                    headers={ACCESS_TOKEN: api_key},
+                    json=new_record)
+    with open("tests/sample_upload.txt", "rb") as f:
+        upload_response = api_client.post(f"/api/uploadfile/GWAS/t1d/{record_name}/1", headers={ACCESS_TOKEN: api_key},
+                                          files={"file": f})
+        assert upload_response.status_code == 200
+    s3_conn = boto3.resource("s3", region_name="us-east-1")
+    file_text = s3_conn.Object("dig-data-registry", f"GWAS/{record_name}/t1d/sample_upload.txt").get()["Body"].read()\
+        .decode("utf-8")
+    assert file_text == "The answer is 47!\n"
+
+
 @pytest.mark.parametrize("df", DataFormat.__members__.values())
 @mock_s3
 def test_valid_data_formats_post(api_client: TestClient, df: DataFormat):


### PR DESCRIPTION
This PR updates the file upload endpoint so that it writes a row to the datasets table upon success and adds a unit test for that code path.  Will each file uploaded be specific to a phenotype?  The existing file structure, s3://dig-analysis-data/variants_raw/WGS/Cade2021_SleepApnea_EU_Female/SpO2per90 seems to imply that.  Anyhow, these code changes try to match the directory conventions in s3://dig-analysis-data/variants_raw and assume that there will be one file upload per phenotype.  Let me know if I've got my wires crossed on this.