### PR TITLE
fix(security): patch 7 high/critical Dependabot vulnerabilities in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/broadinstitute/dig-bioindex.git@master#egg=bioindex
 aiofiles==22.1.0
-aiohttp==3.9.5
+aiohttp==3.13.4
 aiosignal==1.3.1
 alembic==1.9.2
 anyio==3.6.2
@@ -14,7 +14,7 @@ cffi==1.15.1
 charset-normalizer==3.0.1
 click==8.1.3
 coverage==7.4.4
-cryptography==42.0.4
+cryptography==46.0.5
 decorator==5.1.1
 Deprecated==1.2.14
 dnspython==2.3.0
@@ -24,7 +24,7 @@ fabric==3.2.2
 fastapi==0.109.1
 frozenlist==1.4.0
 greenlet==2.0.2
-h11==0.14.0
+h11==0.16.0
 httpcore==0.16.3
 httpx==0.23.3
 idna==3.4
@@ -36,12 +36,12 @@ Mako==1.2.4
 MarkupSafe==2.1.2
 moto==4.1.2
 multidict==6.0.4
-orjson==3.9.15
+orjson==3.11.6
 packaging==23.0
 paramiko==3.3.1
 pipreqs==0.5.0
 pluggy==1.0.0
-pyasn1==0.5.0
+pyasn1==0.6.3
 pycparser==2.21
 pydantic==1.10.2
 PyMySQL==1.1.1
@@ -51,8 +51,8 @@ pytest-cov==4.1.0
 pytest-mock==3.14.0
 python-dateutil==2.8.2
 python-dotenv==1.0.0
-pyjwt[crypto]==2.4.0
-python-multipart==0.0.7
+pyjwt[crypto]==2.12.0
+python-multipart==0.0.22
 PyYAML==6.0
 requests==2.31.0
 responses==0.22.0


### PR DESCRIPTION
## Summary
- Patches 1 critical + 6 high severity Dependabot alerts across 7 packages
- Only `requirements.txt` version strings are changed — no functional code modifications
- CI will validate compatibility

## Packages Updated

| Package | Old | New | Severity | Key CVE(s) |
|---------|-----|-----|----------|------------|
| `aiohttp` | 3.9.5 | 3.13.4 | High | GHSA-jwhx-xcg6-8xhj (request smuggling) |
| `cryptography` | 42.0.4 | 46.0.5 | Critical | CVE-2024-26130, CVE-2024-12747 (memory corruption, NULL deref) |
| `h11` | 0.14.0 | 0.16.0 | High | CVE-2025-43859 (HTTP request smuggling) |
| `orjson` | 3.9.15 | 3.11.6 | High | GHSA-x7c4-6c7g-jf3x (memory safety) |
| `pyasn1` | 0.5.0 | 0.6.3 | High | CVE-2024-23342 (timing side-channel attack) |
| `pyjwt[crypto]` | 2.4.0 | 2.12.0 | High | CVE-2024-53861 (algorithm confusion / key confusion) |
| `python-multipart` | 0.0.7 | 0.0.22 | High | CVE-2024-24762 (ReDoS denial of service) |

## Test plan
- [ ] CI pytest suite passes
- [ ] No import errors from version incompatibilities