### PR TITLE
Hermes fixes: slim list endpoint, genome_build refactor, auto column-map

### DIFF
--- a/dataregistry/api/api.py
+++ b/dataregistry/api/api.py
@@ -15,6 +15,7 @@ import sqlalchemy
 import xmltodict
 from botocore.exceptions import ClientError
 from fastapi import Depends, Body, Header, Query, UploadFile
+from pydantic import BaseModel
 from starlette.background import BackgroundTasks
 from starlette.requests import Request
 from starlette.responses import StreamingResponse, Response, RedirectResponse
@@ -22,6 +23,7 @@ from streaming_form_data import StreamingFormDataParser
 from streaming_form_data.targets import S3Target
 
 from dataregistry.api import query, s3, file_utils, ecs, bioidx, batch, liftover
+from dataregistry.api.mskkp import suggest_column_map
 from dataregistry.api.db import DataRegistryReadWriteDB
 from dataregistry.api.google_oauth import get_google_user
 from dataregistry.api.hermes_file_validation import validate_file
@@ -249,6 +251,68 @@ async def upload_csv(request: Request):
 @router.get("/hermes-upload-columns")
 async def hermes_upload_columns():
     return HERMES_VALIDATOR.column_options()
+
+
+# Common GWAS column-header aliases mapped to Hermes' canonical target names.
+# NOTE on ref/alt semantics: Hermes' downstream QC pipeline treats
+# column_map.reference as the non-effect allele and column_map.alt as the
+# effect allele (see metadata aliasing in validate_hermes_csv below).  These
+# aliases follow that convention, which differs from the mskkp dict.
+HERMES_COLUMN_ALIASES = {
+    # chromosome
+    'chr': 'chromosome', 'chrom': 'chromosome', '#chrom': 'chromosome',
+    '#chr': 'chromosome', 'chromosome': 'chromosome',
+    # position
+    'bp': 'position', 'pos': 'position', 'position': 'position',
+    'base_pair_location': 'position', 'bp_pos': 'position', 'genpos': 'position',
+    # non-effect allele (ref / a2 / other)
+    'ref': 'non-effect allele', 'a2': 'non-effect allele',
+    'other_allele': 'non-effect allele', 'non_effect_allele': 'non-effect allele',
+    'allele2': 'non-effect allele', 'noneffectallele': 'non-effect allele',
+    'reference': 'non-effect allele', 'nea': 'non-effect allele',
+    # effect allele (alt / a1)
+    'alt': 'effect allele', 'a1': 'effect allele',
+    'effect_allele': 'effect allele', 'allele1': 'effect allele',
+    'effectallele': 'effect allele', 'ea': 'effect allele',
+    'coded_allele': 'effect allele',
+    # pValue
+    'p': 'pValue', 'pval': 'pValue', 'pvalue': 'pValue',
+    'p_value': 'pValue', 'p-value': 'pValue', 'p_val': 'pValue',
+    # N total
+    'n': 'N total', 'n_total': 'N total', 'sample_size': 'N total',
+    'samplesize': 'N total', 'total_n': 'N total', 'neff': 'N total',
+    # standard error
+    'se': 'se', 'stderr': 'se', 'standard_error': 'se',
+    'std_err': 'se', 'sebeta': 'se',
+    # maf / eaf
+    'maf': 'maf', 'minor_allele_frequency': 'maf',
+    'eaf': 'eaf', 'effect_allele_frequency': 'eaf',
+    'a1freq': 'eaf', 'a1_freq': 'eaf', 'freq': 'eaf', 'frq': 'eaf',
+    # N cases
+    'cases': 'N cases', 'n_cases': 'N cases',
+    'ncases': 'N cases', 'n_case': 'N cases',
+    # beta
+    'beta': 'beta', 'effect': 'beta', 'effect_size': 'beta', 'b': 'beta',
+    # oddsRatio / bounds
+    'or': 'oddsRatio', 'odds_ratio': 'oddsRatio', 'oddsratio': 'oddsRatio',
+    'or_lb': 'oddsRatioLB', 'or_lower': 'oddsRatioLB', 'ci_lower': 'oddsRatioLB',
+    'or_ub': 'oddsRatioUB', 'or_upper': 'oddsRatioUB', 'ci_upper': 'oddsRatioUB',
+}
+
+
+class HermesColumnMapSuggestionRequest(BaseModel):
+    columns: List[str]
+
+
+@router.post("/hermes/suggest-column-map")
+async def suggest_hermes_column_mapping(
+    request: HermesColumnMapSuggestionRequest,
+    user: User = Depends(get_current_user),
+):
+    """Suggest mappings from uploaded-file columns to Hermes required/optional targets."""
+    target_fields = HERMES_VALIDATOR.required_columns + HERMES_VALIDATOR.optional_columns
+    suggested = suggest_column_map(request.columns, target_fields, aliases=HERMES_COLUMN_ALIASES)
+    return {"suggested_map": suggested, "target_fields": target_fields}
 
 
 @router.get("/hermes-uploaded-phenotypes")

--- a/dataregistry/api/api.py
+++ b/dataregistry/api/api.py
@@ -407,6 +407,12 @@ async def validate_hermes_csv(request: QCHermesFileRequest, background_tasks: Ba
     if validation_errors:
         return {"errors": validation_errors}
 
+    # Stamp metadata.referenceGenome with the request's authoritative build so
+    # liftover decisioning and stored state cannot disagree, and downstream
+    # reads of metadata.referenceGenome (via the SELECT-time normalizer) find
+    # a value.
+    metadata['referenceGenome'] = request.genome_build.value
+
     script_options = {k: v for k, v in request.qc_script_options.dict().items() if v is not None}
     s3.upload_metadata(metadata, f"hermes/{dataset}")
 
@@ -423,7 +429,6 @@ async def validate_hermes_csv(request: QCHermesFileRequest, background_tasks: Ba
     file_guid = query.save_file_upload_info(
         engine, dataset, metadata, s3_path, filename, file_size, user.user_name,
         script_options,
-        genome_build=request.genome_build.value,
         initial_qc_status=initial_qc_status,
     )
 

--- a/dataregistry/api/query.py
+++ b/dataregistry/api/query.py
@@ -407,27 +407,24 @@ def retrieve_meta_data_mapping(engine, user: str) -> [dict]:
         return {row.dataset: json.loads(row.metadata) for row in results}
 
 def save_file_upload_info(engine, dataset, metadata, s3_path, filename, file_size, uploader, qc_script_options,
-                          genome_build=None, initial_qc_status='SUBMITTED TO QC') -> str:
+                          initial_qc_status='SUBMITTED TO QC') -> str:
     """Insert a new file_uploads row.
 
-    genome_build defaults to GenomeBuild.na.value when not provided so that
-    existing callers (including tests) keep working without changes.
+    The assembly build is carried in metadata.referenceGenome — not a dedicated
+    column — so it does not appear in this INSERT.
     initial_qc_status allows the liftover flow to set 'SUBMITTED TO LIFTOVER'
     before the normal 'SUBMITTED TO QC'.
     """
-    if genome_build is None:
-        genome_build = GenomeBuild.na.value
     with engine.connect() as conn:
         new_guid = str(uuid.uuid4())
         conn.execute(text("""INSERT INTO file_uploads(id, dataset, file_name, file_size, uploaded_at, uploaded_by,
-        metadata, s3_path, qc_script_options, genome_build, qc_status) VALUES(:id, :dataset, :file_name, :file_size,
-        NOW(), :uploaded_by, :metadata, :s3_path, :qc_script_options, :genome_build, :initial_qc_status)"""),
+        metadata, s3_path, qc_script_options, qc_status) VALUES(:id, :dataset, :file_name, :file_size,
+        NOW(), :uploaded_by, :metadata, :s3_path, :qc_script_options, :initial_qc_status)"""),
                      {'id': new_guid.replace('-', ''), 'dataset': dataset,
                       'file_name': filename,
                       'file_size': file_size, 'uploaded_by': uploader,
                       'metadata': json.dumps(metadata), 's3_path': s3_path,
                       'qc_script_options': json.dumps(qc_script_options),
-                      'genome_build': genome_build,
                       'initial_qc_status': initial_qc_status})
         conn.commit()
         return new_guid
@@ -443,9 +440,23 @@ def update_file_qc_options(engine, file_id: str, qc_script_options: dict):
         conn.commit()
 
 
+GENOME_BUILD_NORMALIZER_SQL = (
+    "CASE LOWER(metadata->>'$.referenceGenome') "
+    "WHEN 'hg19' THEN 'hg19' "
+    "WHEN 'hg38' THEN 'grch38' "
+    "WHEN 'grch37' THEN 'hg19' "
+    "WHEN 'grch38' THEN 'grch38' "
+    "ELSE 'n/a' END"
+)
+
+
 def gen_fetch_ds_sql(params, param_to_where):
-    sql = "select id, dataset as dataset_name, file_name, file_size, uploaded_at, uploaded_by, qc_status, " \
-          "qc_log, metadata->>'$.phenotype' as phenotype, metadata->>'$.ancestry' as ancestry, metadata, s3_path from file_uploads "
+    # qc_log is intentionally omitted here — it's a large TEXT column and no
+    # list-endpoint caller reads it.  The per-file fetch_file_upload still
+    # returns qc_log for the QC report page.
+    sql = ("select id, dataset as dataset_name, file_name, file_size, uploaded_at, uploaded_by, qc_status, "
+           f"{GENOME_BUILD_NORMALIZER_SQL} as genome_build, "
+           "metadata->>'$.phenotype' as phenotype, metadata->>'$.ancestry' as ancestry, metadata, s3_path from file_uploads ")
 
     for index, (col, value) in enumerate(params.items(), start=0):
         if col in {"limit", "offset"}:
@@ -589,13 +600,15 @@ def update_file_upload_after_liftover(engine, file_id, qc_status, genome_build=N
     """Update file_uploads after a liftover attempt.
 
     genome_build is only flipped when liftover SUCCEEDED; pass None to skip.
+    The assembly is stored in metadata.referenceGenome, not a dedicated column.
     """
     file_id_no_dashes = str(file_id).replace('-', '')
     with engine.connect() as conn:
         if genome_build is not None:
             conn.execute(text("""
                 UPDATE file_uploads
-                SET qc_status = :qc_status, genome_build = :genome_build
+                SET qc_status = :qc_status,
+                    metadata = JSON_SET(metadata, '$.referenceGenome', :genome_build)
                 WHERE id = :file_id
             """), {
                 'qc_status': qc_status.value if hasattr(qc_status, 'value') else qc_status,
@@ -660,7 +673,8 @@ def fetch_file_upload(engine, file_id) -> Union[FileUpload, None]:
     with engine.connect() as conn:
         result = conn.execute(
             text("SELECT id, dataset as dataset_name, file_name, file_size, uploaded_at, uploaded_by, metadata, "
-                 "s3_path, qc_log, metadata->>'$.phenotype' as phenotype, qc_status, qc_script_options "
+                 f"s3_path, qc_log, metadata->>'$.phenotype' as phenotype, {GENOME_BUILD_NORMALIZER_SQL} as genome_build, "
+                 "qc_status, qc_script_options "
                  "FROM file_uploads WHERE id = :file_id"),
             {'file_id': file_id}).first()
 

--- a/migrations/versions/2026_04_23_1200-drop_file_uploads_genome_build.py
+++ b/migrations/versions/2026_04_23_1200-drop_file_uploads_genome_build.py
@@ -1,0 +1,52 @@
+"""drop file_uploads.genome_build (read from metadata.referenceGenome)
+
+Revision ID: drop_file_uploads_genome_build
+Revises: add_liftover_tables
+Create Date: 2026-04-23 12:00:00.000000
+
+The assembly build for a Hermes upload has always been persisted as part of
+the JSON metadata blob (`metadata.referenceGenome`, values "Hg19"/"Hg38").
+The dedicated column added in add_liftover_tables was redundant: the upload
+path duplicated the build into both places, and the list endpoint never
+selected the column, so every `/hermes` row displayed the default 'n/a'.
+
+We drop the column and normalize at read time in application queries
+(CASE on `metadata->>'$.referenceGenome'`).  Liftover completion continues
+to update the build in-place — now via JSON_SET on the metadata column.
+"""
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = 'drop_file_uploads_genome_build'
+down_revision = 'add_liftover_tables'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(text("""
+        ALTER TABLE `file_uploads`
+        DROP COLUMN `genome_build`
+    """))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    # Re-add the column, then backfill from metadata.referenceGenome using the
+    # same normalization the application's SELECT does at read-time.
+    conn.execute(text("""
+        ALTER TABLE `file_uploads`
+        ADD COLUMN `genome_build` VARCHAR(16) NOT NULL DEFAULT 'n/a' AFTER `qc_job_completed_at`
+    """))
+    conn.execute(text("""
+        UPDATE `file_uploads`
+        SET `genome_build` = CASE LOWER(metadata->>'$.referenceGenome')
+            WHEN 'hg19'   THEN 'hg19'
+            WHEN 'hg38'   THEN 'grch38'
+            WHEN 'grch37' THEN 'hg19'
+            WHEN 'grch38' THEN 'grch38'
+            ELSE 'n/a'
+        END
+    """))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -485,7 +485,8 @@ def test_validate_hermes_build_mismatch_triggers_liftover(mocker, api_client: Te
     # file_uploads row has correct initial state
     with engine.connect() as conn:
         row = conn.execute(
-            text("SELECT qc_status, genome_build FROM file_uploads WHERE id = :id"),
+            text(f"SELECT qc_status, {query.GENOME_BUILD_NORMALIZER_SQL} AS genome_build "
+                 f"FROM file_uploads WHERE id = :id"),
             {'id': file_id.replace('-', '')},
         ).first()
     assert row.qc_status == HermesFileStatus.SUBMITTED_TO_LIFTOVER.value
@@ -538,7 +539,8 @@ def test_validate_hermes_build_match_goes_to_qc(mocker, api_client: TestClient):
     # file_uploads row should go directly to SUBMITTED TO QC
     with engine.connect() as conn:
         row = conn.execute(
-            text("SELECT qc_status, genome_build FROM file_uploads WHERE id = :id"),
+            text(f"SELECT qc_status, {query.GENOME_BUILD_NORMALIZER_SQL} AS genome_build "
+                 f"FROM file_uploads WHERE id = :id"),
             {'id': file_id.replace('-', '')},
         ).first()
     assert row.qc_status == HermesFileStatus.SUBMITTED_TO_QC.value

--- a/tests/test_endpoints_liftover.py
+++ b/tests/test_endpoints_liftover.py
@@ -42,13 +42,15 @@ def _create_file_and_liftover_job(engine, uploader="testuser@broadinstitute.org"
     file_id = query.save_file_upload_info(
         engine,
         dataset="liftover-endpoint-test-ds",
-        metadata={"column_map": {"chromosome": "CHR", "position": "BP"}},
+        metadata={
+            "column_map": {"chromosome": "CHR", "position": "BP"},
+            "referenceGenome": "grch38",
+        },
         s3_path="hermes/liftover-endpoint-test-ds/file.csv",
         filename="file.csv",
         file_size=500,
         uploader=uploader,
         qc_script_options={"fd": 0.2},
-        genome_build="grch38",
         initial_qc_status="SUBMITTED TO LIFTOVER",
     )
     job_id = str(uuid.uuid4())

--- a/tests/test_liftover.py
+++ b/tests/test_liftover.py
@@ -33,17 +33,26 @@ def engine():
 # ---------------------------------------------------------------------------
 
 def _make_file_id(engine, genome_build="grch38", initial_qc_status="SUBMITTED TO LIFTOVER"):
-    """Create a minimal file_uploads row and return its ID (no dashes)."""
+    """Create a minimal file_uploads row and return its ID (no dashes).
+
+    genome_build is written into metadata.referenceGenome — the schema no
+    longer has a dedicated column.  The SELECT-side normalizer in
+    query.GENOME_BUILD_NORMALIZER_SQL maps it back to a GenomeBuild enum
+    value for tests that assert on row.genome_build.
+    """
+    metadata = {
+        "column_map": {"chromosome": "CHR", "position": "BP"},
+        "referenceGenome": genome_build,
+    }
     fid = query.save_file_upload_info(
         engine,
         dataset="test-dataset",
-        metadata={"column_map": {"chromosome": "CHR", "position": "BP"}},
+        metadata=metadata,
         s3_path="hermes/test-dataset/test.csv",
         filename="test.csv",
         file_size=1234,
         uploader="tester@example.org",
         qc_script_options={"fd": 0.2},
-        genome_build=genome_build,
         initial_qc_status=initial_qc_status,
     )
     return fid
@@ -52,9 +61,11 @@ def _make_file_id(engine, genome_build="grch38", initial_qc_status="SUBMITTED TO
 def _fetch_file_row(engine, file_id):
     """Fetch raw file_uploads row for assertions."""
     from sqlalchemy import text
+    from dataregistry.api.query import GENOME_BUILD_NORMALIZER_SQL
     with engine.connect() as conn:
         row = conn.execute(
-            text("SELECT qc_status, genome_build FROM file_uploads WHERE id = :id"),
+            text(f"SELECT qc_status, {GENOME_BUILD_NORMALIZER_SQL} AS genome_build "
+                 f"FROM file_uploads WHERE id = :id"),
             {"id": str(file_id).replace("-", "")},
         ).first()
     return row


### PR DESCRIPTION
## Summary

- **Slim `/upload-hermes` list response**: drop `qc_log` from the SELECT — no list caller reads it and it can exceed 60 KB/row.  Per-file `fetch_file_upload` still returns `qc_log` for the QC report page.
- **Drop `file_uploads.genome_build` column**: move to `metadata.referenceGenome` as the single source of truth, with a SELECT-time CASE normalizer (`GENOME_BUILD_NORMALIZER_SQL`) so the response shape is unchanged.  Fixes the bug where the `/hermes` list always showed `n/a` for Build regardless of the upload's actual assembly.  `validate_hermes_csv` now stamps `metadata.referenceGenome` from `request.genome_build.value` so the request's authoritative build is reliably persisted.
- **`POST /hermes/suggest-column-map`**: new endpoint mirroring the hcm/mskkp pattern.  Pre-fills the column-mapping dropdowns on upload by matching common GWAS headers (`CHR`/`POS`/`A1`/`A2`/`PVAL`/`SE`/`BETA`/…) to Hermes targets.  Reuses the shared `suggest_column_map` from `mskkp.py` with a hermes-specific alias dict.

Pairs with the frontend PR in broadinstitute/data-registry.

## Test plan

- [x] `pytest tests/` — 97/97 passing locally
- [x] Alembic `upgrade head` + `downgrade -1` both apply cleanly against local docker DB
- [ ] QA deploy completes successfully
- [ ] `/api/upload-hermes` payload size drops meaningfully (no qc_log bodies)
- [ ] `/api/upload-hermes/{id}` still returns `log` for the QC detail page
- [ ] `/hermes` list shows real `genome_build` values for existing records (Liftover Real 6 → grch38, not n/a)
- [ ] `POST /api/hermes/suggest-column-map` returns sensible suggestions for a realistic header set

🤖 Generated with [Claude Code](https://claude.com/claude-code)