### PR TITLE
Configurable KPN_CMS_FILES_BASE for CMS asset URL rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Config:
   requests are proxied there, persisted, and logged to `cms_request_miss`.
   Set to `false` at domain retirement.
 - `KPN_CMS_SOURCE_HOST` (default `https://kp4cd.org`)
+- `KPN_CMS_FILES_BASE` (default `/api/kpn/files`, root-relative) — the base URL
+  baked into content payloads for mirrored assets **at import time**. The
+  root-relative default requires portal origins to proxy `/api/kpn/*` here; set
+  an absolute base (e.g. `https://api.kpndataregistry.org/api/kpn/files`) when
+  running the import so portal domains need no proxy. Changing it later just
+  means re-running the import.
 - Assets land in a dedicated public-content bucket, `KPN_CMS_ASSETS_BUCKET`
   (default `dig-kpn-cms-assets`), under the `kpn-cms-assets/` prefix — separate
   from the controlled-data registry bucket so its access policy can diverge

--- a/dataregistry/api/kpn_cms_assets.py
+++ b/dataregistry/api/kpn_cms_assets.py
@@ -60,14 +60,27 @@ def asset_path(url: str) -> str:
     return urllib.parse.unquote(clean_url.split(_FILES_PREFIX, 1)[1])
 
 
+def files_url_base() -> str:
+    """Base URL baked into rewritten payloads at import time.
+
+    Default is root-relative, which requires the portal origin to proxy
+    /api/kpn/* to this API. Set KPN_CMS_FILES_BASE to an absolute base
+    (e.g. https://api.kpndataregistry.org/api/kpn/files) so portal domains
+    need no proxy — content then points straight at the API host.
+    """
+    return os.environ.get('KPN_CMS_FILES_BASE', '/api/kpn/files').rstrip('/')
+
+
 def rewrite_asset_urls(text_blob: str) -> str:
+    base = files_url_base()
+
     def _sub(m):
         raw = m.group(1)
         path = _unescape(raw)
         if not path.startswith(_FILES_PREFIX):
             return m.group(0)          # non-asset kp4cd link (e.g. /contact): untouched
         clean_path = _strip_query_fragment(path)
-        new = '/api/kpn/files/' + clean_path[len(_FILES_PREFIX):]
+        new = base + '/' + clean_path[len(_FILES_PREFIX):]
         return new.replace('/', '\\/') if '\\/' in raw else new
     return _ASSET_RE.sub(_sub, text_blob)
 

--- a/tests/kpn_cms/test_assets.py
+++ b/tests/kpn_cms/test_assets.py
@@ -166,3 +166,15 @@ def test_query_strings_with_all_forms():
     assert out_escaped_frag.endswith('\\"'), "Should end with escaped quote"
     assert '\\/api\\/kpn\\/files\\/image.png' in out_escaped_frag, "Rewritten path should be escaped"
     assert '#section' not in out_escaped_frag, "Fragment should be stripped from rewrite"
+
+
+def test_rewrite_respects_files_base_env(monkeypatch):
+    monkeypatch.setenv('KPN_CMS_FILES_BASE', 'https://api.example.org/api/kpn/files/')
+    out = a.rewrite_asset_urls(BLOB)
+    assert 'https://api.example.org/api/kpn/files/inline-images/data_icon4.png' in out
+    assert 'url(https://api.example.org/api/kpn/files/vueportal/t2d_bg.png)' in out
+    # escaped form stays escaped, with the absolute base escaped too
+    assert 'https:\\/\\/api.example.org\\/api\\/kpn\\/files\\/news_thumbnails\\/small.svg' in out
+    assert 'kp4cd.org/sites/default/files' not in out
+    monkeypatch.delenv('KPN_CMS_FILES_BASE')
+    assert '/api/kpn/files/inline-images/data_icon4.png' in a.rewrite_asset_urls(BLOB)


### PR DESCRIPTION
Resolves the portal-integration finding from local E2E testing: rewritten asset URLs were hardcoded root-relative (`/api/kpn/files/...`), which resolves against the portal's origin and therefore requires every portal domain to proxy `/api/kpn/*` to this API.

`KPN_CMS_FILES_BASE` (default unchanged: `/api/kpn/files`) lets the import bake an absolute base into payloads instead — e.g. `https://api.kpndataregistry.org/api/kpn/files` — so the portal host swap needs no nginx changes. Applied at import time only; switching strategies later is just a re-import.

Tests: new `test_rewrite_respects_files_base_env` (absolute base, escaped + unescaped forms, default fallback); full kpn suite 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2835YBpj4gFwtFUfmbDf7