### PR TITLE
kp_datasets: first-class store for KP dataset info (kp4cd.org retirement, phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ but is still the only live source of these views (hugeampkpncms.org serves a
 different API generation), so this store + import + compatible API replace it.
 Full audit and runbook live in the KP4CD Re-architecture project's support folder.
 
+`datasetinfo` is the one exception: it is now served from the registry's own
+`kp_datasets` table (the system of record for dataset content), populated and
+refreshed by `python -m scripts.migrate_kp_datasets` (reads the kp4cd Drupal
+RDS directly via the `kp4cd-220214` secret). `scripts/import_kpn_cms.py` no
+longer touches `datasetinfo`.
+
 Populate / refresh the content snapshot (requires kp4cd.org to be reachable):
 
     python -m scripts.import_kpn_cms --dry-run   # review the URL set first

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # data-registry-api
-![Coverage](https://img.shields.io/badge/coverage-69%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-70%25-brightgreen)
 
 ## Running the server
 ### Running Locally

--- a/dataregistry/api/kp_datasets_envelope.py
+++ b/dataregistry/api/kp_datasets_envelope.py
@@ -1,0 +1,50 @@
+"""Synthesize the Drupal node envelope the portal frontends expect from a
+kp_datasets row (captured live shape: tests/kpn_cms/fixtures/datasetinfo_sample.json).
+
+Authored fields carry real values. Drupal bookkeeping fields the frontends
+never read (uuid, vid, revision_*, uid, ...) get deterministic synthetic
+values so responses are stable across requests and deploys.
+"""
+import uuid
+
+_DATE_FMT = 'Y-m-d\\TH:i:sP'
+_TYPE_UUID = '5dfdf16a-041b-40a0-8deb-37d1255a4bc6'   # kp_dataset node type uuid on kp4cd.org
+_UID = 22                                             # historical content-author uid on kp4cd.org
+_USER_UUID = '1b3bbbf7-364b-4ff6-86e8-6bf26e3d6cf9'
+_NID_OFFSET = 100000                                  # synthetic nids for post-Drupal rows
+
+
+def _ts(dt):
+    return {'value': dt.strftime('%Y-%m-%dT%H:%M:%S+00:00'), 'format': _DATE_FMT}
+
+
+def node_envelope(row):
+    nid = row['drupal_nid'] if row['drupal_nid'] is not None else _NID_OFFSET + row['id']
+    user = {'target_id': _UID, 'target_type': 'user', 'target_uuid': _USER_UUID,
+            'url': f'/user/{_UID}'}
+    return {
+        'nid': [{'value': nid}],
+        'uuid': [{'value': str(uuid.uuid5(uuid.NAMESPACE_URL, f'kpn-dataset-{nid}'))}],
+        'vid': [{'value': nid}],
+        'langcode': [{'value': 'en'}],
+        'type': [{'target_id': 'kp_dataset', 'target_type': 'node_type',
+                  'target_uuid': _TYPE_UUID}],
+        'revision_timestamp': [_ts(row['updated_at'])],
+        'revision_uid': [dict(user)],
+        'revision_log': [],
+        'status': [{'value': bool(row['published'])}],
+        'uid': [dict(user)],
+        'title': [{'value': row['title']}],
+        'created': [_ts(row['created_at'])],
+        'changed': [_ts(row['updated_at'])],
+        'promote': [{'value': True}],
+        'sticky': [{'value': False}],
+        'default_langcode': [{'value': True}],
+        'revision_translation_affected': [{'value': True}],
+        'path': [{'alias': None, 'pid': None, 'langcode': 'en'}],
+        'body': [{'value': row['body'], 'format': 'full_html',
+                  'processed': row['body'], 'summary': ''}],
+        'field_dataset_id': ([{'value': row['dataset_id']}]
+                             if row['dataset_id'] is not None else []),
+        'field_portals': [{'value': row['portals']}],
+    }

--- a/dataregistry/api/kp_datasets_query.py
+++ b/dataregistry/api/kp_datasets_query.py
@@ -38,18 +38,17 @@ def get_by_dataset_id(engine, dataset_id, published_only=True):
 def list_recent(engine, portal=None, limit=10):
     """Published rows, newest updated first; optional exact portal-code filter.
 
-    Portal filtering happens in Python: portals is a comma-separated string
-    ('md, t2d, a2f') and a SQL LIKE would let 'md' match 'mdep'. The table
-    tops out around a thousand rows, so fetching published rows is cheap.
+    FIND_IN_SET over the space-stripped portal list is token-exact ('md'
+    never matches 'mdep'), and the LIMIT keeps mediumtext bodies for only
+    the returned rows instead of every published row.
     """
     with engine.connect() as con:
-        rows = [dict(r) for r in con.execute(text(
+        rows = con.execute(text(
             "SELECT * FROM kp_datasets WHERE published = 1 "
-            "ORDER BY updated_at DESC, id DESC")).mappings().fetchall()]
-    if portal is not None:
-        rows = [r for r in rows
-                if portal in [p.strip() for p in r['portals'].split(',')]]
-    return rows[:limit]
+            "AND (:p IS NULL OR FIND_IN_SET(:p, REPLACE(portals, ' ', ''))) "
+            "ORDER BY updated_at DESC, id DESC LIMIT :n"
+        ), {'p': portal, 'n': limit}).mappings().fetchall()
+    return [dict(r) for r in rows]
 
 
 def backfill_registry_links(engine) -> int:

--- a/dataregistry/api/kp_datasets_query.py
+++ b/dataregistry/api/kp_datasets_query.py
@@ -1,0 +1,75 @@
+"""Store operations for kp_datasets — the system of record for portal-facing
+KP dataset info after the kp4cd.org migration.
+
+Spec: docs/superpowers/specs/2026-08-14-kp-datasets-migration-design.md
+"""
+from sqlalchemy import text
+
+
+def upsert_kp_dataset(engine, row) -> None:
+    """Insert or update by drupal_nid (the migration's idempotency key)."""
+    with engine.begin() as con:
+        con.execute(text("""
+            INSERT INTO kp_datasets
+                (dataset_id, title, body, portals, published, drupal_nid,
+                 drupal_author, migration_note, created_at, updated_at)
+            VALUES (:dataset_id, :title, :body, :portals, :published,
+                    :drupal_nid, :drupal_author, :migration_note,
+                    :created_at, :updated_at)
+            ON DUPLICATE KEY UPDATE
+                dataset_id = VALUES(dataset_id), title = VALUES(title),
+                body = VALUES(body), portals = VALUES(portals),
+                published = VALUES(published),
+                drupal_author = VALUES(drupal_author),
+                migration_note = VALUES(migration_note),
+                created_at = VALUES(created_at), updated_at = VALUES(updated_at)
+        """), row)
+
+
+def get_by_dataset_id(engine, dataset_id, published_only=True):
+    sql = "SELECT * FROM kp_datasets WHERE dataset_id = :d"
+    if published_only:
+        sql += " AND published = 1"
+    with engine.connect() as con:
+        r = con.execute(text(sql), {'d': dataset_id}).mappings().fetchone()
+    return dict(r) if r else None
+
+
+def list_recent(engine, portal=None, limit=10):
+    """Published rows, newest updated first; optional exact portal-code filter.
+
+    Portal filtering happens in Python: portals is a comma-separated string
+    ('md, t2d, a2f') and a SQL LIKE would let 'md' match 'mdep'. The table
+    tops out around a thousand rows, so fetching published rows is cheap.
+    """
+    with engine.connect() as con:
+        rows = [dict(r) for r in con.execute(text(
+            "SELECT * FROM kp_datasets WHERE published = 1 "
+            "ORDER BY updated_at DESC, id DESC")).mappings().fetchall()]
+    if portal is not None:
+        rows = [r for r in rows
+                if portal in [p.strip() for p in r['portals'].split(',')]]
+    return rows[:limit]
+
+
+def backfill_registry_links(engine) -> int:
+    """Link kp_datasets rows to datasets rows sharing the exact name.
+
+    BINARY comparison: MySQL's default collation is case-insensitive, but the
+    spec requires exact matches only.
+    """
+    with engine.begin() as con:
+        res = con.execute(text("""
+            UPDATE kp_datasets k
+            JOIN datasets d ON BINARY d.name = BINARY k.dataset_id
+            SET k.registry_dataset_id = d.id
+        """))
+    return res.rowcount
+
+
+def delete_cms_datasetinfo_rows(engine) -> int:
+    """Drop the superseded Drupal-snapshot rows; serving now uses kp_datasets."""
+    with engine.begin() as con:
+        res = con.execute(text(
+            "DELETE FROM cms_content_item WHERE view_name = 'datasetinfo'"))
+    return res.rowcount

--- a/dataregistry/api/kpn_cms.py
+++ b/dataregistry/api/kpn_cms.py
@@ -6,6 +6,10 @@ same field names, HTML-in-strings untouched; only asset URLs are rewritten to
 until the next import run mirrors their assets). Content is populated by
 scripts/import_kpn_cms.py; unknown requests fall back to a feature-flagged
 proxy against the live CMS while it exists (KPN_CMS_PROXY_ON_MISS).
+
+Exception: datasetinfo is served from the registry's kp_datasets table (the
+system of record, populated/refreshed by scripts/migrate_kp_datasets.py),
+not from scripts/import_kpn_cms.py, and has no proxy-on-miss fallback.
 """
 import os
 import re

--- a/dataregistry/api/kpn_cms.py
+++ b/dataregistry/api/kpn_cms.py
@@ -21,6 +21,8 @@ from dataregistry.api.db import DataRegistryReadWriteDB
 from dataregistry.api import kpn_cms_query as q
 from dataregistry.api.kpn_cms_assets import ASSET_PREFIX, ASSETS_BUCKET, BROWSER_UA
 from dataregistry.api.kpn_cms_ingest import rows_for
+from dataregistry.api import kp_datasets_query as kq
+from dataregistry.api.kp_datasets_envelope import node_envelope
 
 router = fastapi.APIRouter()
 engine = DataRegistryReadWriteDB().get_engine()
@@ -49,7 +51,7 @@ _ITEM_KEY_MAXLEN = 255
 FILTER_PARAM = {
     'news2vueportal': 'portal', 'kpdatasets': 'portal', 'newfeatures': 'portal',
     'newresources': 'portal', 'eglmethodsperportal': 'portal', 'portal_front': 'portal',
-    'content_by_id': 'nid', 'datasetinfo': 'datasetid', 'eglmethod': 'from',
+    'content_by_id': 'nid', 'eglmethod': 'from',
     'static_content': 'field_page', 'paperheadermenu': 'paper',
 }
 
@@ -128,6 +130,18 @@ def kpn_help_book_search(body: str = ''):
     return q.search_help_book(engine, body)
 
 
+def _datasetinfo(params):
+    """kp_datasets is the system of record for datasetinfo -- no snapshot
+    lookup, no proxy-on-miss, no miss recording."""
+    ds = params.get('datasetid')
+    if ds is not None:
+        row = kq.get_by_dataset_id(engine, ds[:_ITEM_KEY_MAXLEN])
+        return [node_envelope(row)] if row else []
+    portal = params.get('portal')
+    rows = kq.list_recent(engine, portal=portal[:_PORTAL_MAXLEN] if portal else None)
+    return [node_envelope(r) for r in rows]
+
+
 @router.get('/kpn/rest/views/{view_name}')
 def kpn_view(view_name: str, request: Request):
     view_name = view_name[:_VIEW_NAME_MAXLEN]
@@ -135,6 +149,8 @@ def kpn_view(view_name: str, request: Request):
     if not _NAME_RE.match(view_name):
         q.record_miss(engine, view_name, q.canonical_key(params), False, None)
         return []
+    if view_name == 'datasetinfo':
+        return _datasetinfo(params)
     rows, scope_col, scope_val = _lookup(view_name, params)
     if rows:
         return rows

--- a/migrations/versions/2026_08_17_1200-create_kp_datasets_table.py
+++ b/migrations/versions/2026_08_17_1200-create_kp_datasets_table.py
@@ -1,0 +1,43 @@
+"""create kp_datasets table (portal-facing dataset info, system of record)
+
+Revision ID: create_kp_datasets
+Revises: create_kpn_cms_tables
+Create Date: 2026-08-17 12:00:00.000000
+
+"""
+from alembic import op
+from sqlalchemy import text
+
+revision = 'create_kp_datasets'
+down_revision = 'create_kpn_cms_tables'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(text("""
+        CREATE TABLE `kp_datasets` (
+            `id` int NOT NULL AUTO_INCREMENT,
+            `dataset_id` varchar(255) NULL,
+            `title` varchar(500) NOT NULL,
+            `body` mediumtext NOT NULL,
+            `portals` varchar(500) NOT NULL,
+            `published` tinyint(1) NOT NULL,
+            `registry_dataset_id` binary(32) NULL,
+            `drupal_nid` int NULL,
+            `drupal_author` varchar(255) NULL,
+            `migration_note` varchar(255) NULL,
+            `created_at` datetime NOT NULL,
+            `updated_at` datetime NOT NULL,
+            PRIMARY KEY (`id`),
+            UNIQUE KEY `kp_datasets_dataset_id_uq` (`dataset_id`),
+            UNIQUE KEY `kp_datasets_drupal_nid_uq` (`drupal_nid`),
+            KEY `kp_datasets_registry_dataset_idx` (`registry_dataset_id`)
+        )
+    """))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(text("DROP TABLE `kp_datasets`"))

--- a/scripts/import_kpn_cms.py
+++ b/scripts/import_kpn_cms.py
@@ -94,24 +94,6 @@ def run_import(engine, s3_client, bucket, source_host, bioindex_host,
         _import(view, f'/rest/views/{view}', None, None)
 
     if not dry_run:
-        # datasetinfo keyed fetches. Id source: per-portal datasetinfo?portal=
-        # listing calls (kpdatasets is dead in production — 404 under every
-        # parameterization, incl. what the live frontend sends; the datasetinfo
-        # view called with portal= returns the dataset node listing including
-        # field_dataset_id. Evidence: tests/kpn_cms/fixtures/MANIFEST.md).
-        ds_ids = set()
-        for portal in portals:
-            try:
-                listing = fetch_view(source_host, f'/rest/views/datasetinfo?portal={portal}')
-            except requests.RequestException as e:
-                report['skipped'].append(f'datasetinfo listing {portal}: {e}')
-                continue
-            for row in listing:
-                ds_id = _field_value(row.get('field_dataset_id'))
-                if ds_id:
-                    ds_ids.add(ds_id)
-        for ds in sorted(ds_ids):
-            _import('datasetinfo', f'/rest/views/datasetinfo?datasetid={ds}', 'item_key', ds, item_key=ds)
         for nid in sorted(_harvest_nids(engine)):
             _import('content_by_id', f'/rest/views/content_by_id?nid={nid}', 'nid', nid)
 

--- a/scripts/migrate_kp_datasets.py
+++ b/scripts/migrate_kp_datasets.py
@@ -1,0 +1,141 @@
+"""One-off (re-runnable) migration of kp_dataset nodes from the kp4cd.org
+Drupal DB into the registry's kp_datasets table.
+
+Reads the Drupal RDS directly (SELECT only) via the 'kp4cd-220214' secret,
+applies latest-wins dedup on field_dataset_id, upserts by drupal_nid, links
+rows to existing registry datasets by exact name, deletes the superseded
+cms_content_item datasetinfo snapshot, and mirrors/rewrites embedded kp4cd
+asset URLs. Spec: docs/superpowers/specs/2026-08-14-kp-datasets-migration-design.md
+
+    python -m scripts.migrate_kp_datasets --dry-run   # report only, no writes
+    python -m scripts.migrate_kp_datasets
+"""
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+
+import boto3
+import pymysql
+from sqlalchemy import text
+
+from dataregistry.api.db import DataRegistryReadWriteDB
+from dataregistry.api import kp_datasets_query as kq
+from dataregistry.api.kpn_cms_assets import (
+    ASSETS_BUCKET, find_asset_urls, mirror_assets, rewrite_asset_urls)
+
+DRUPAL_SECRET_ID = 'kp4cd-220214'
+
+NODE_SQL = """
+    SELECT n.nid, n.title, n.status, n.created, n.changed, u.mail AS author,
+           d.field_dataset_id_value AS dataset_id,
+           p.field_portals_value AS portals,
+           b.body_value AS body
+    FROM node_field_data n
+    LEFT JOIN node__field_dataset_id d ON d.entity_id = n.nid AND d.deleted = 0
+    LEFT JOIN node__field_portals p ON p.entity_id = n.nid AND p.deleted = 0
+    LEFT JOIN node__body b ON b.entity_id = n.nid AND b.deleted = 0
+    LEFT JOIN users_field_data u ON u.uid = n.uid
+    WHERE n.type = 'kp_dataset'
+"""
+
+
+def fetch_drupal_nodes():
+    sec = json.loads(boto3.client('secretsmanager', region_name='us-east-1')
+                     .get_secret_value(SecretId=DRUPAL_SECRET_ID)['SecretString'])
+    conn = pymysql.connect(host=sec['host'], port=int(sec['port']),
+                           user=sec['username'], password=sec['password'],
+                           database=sec['dbname'], connect_timeout=15,
+                           read_timeout=300,
+                           cursorclass=pymysql.cursors.DictCursor)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(NODE_SQL)
+            return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def dedup_nodes(nodes):
+    """Latest-changed node keeps a duplicated dataset_id; earlier twins are
+    kept but demoted to dataset_id NULL with an explanatory note."""
+    winners = {}
+    for n in nodes:
+        ds = n['dataset_id']
+        if ds and (ds not in winners or n['changed'] > winners[ds]['changed']):
+            winners[ds] = n
+    out = []
+    for n in nodes:
+        n = dict(n)
+        ds = n['dataset_id']
+        if ds and winners[ds]['nid'] != n['nid']:
+            n['migration_note'] = (f'duplicate dataset_id {ds}; '
+                                   f'superseded by nid {winners[ds]["nid"]}')
+            n['dataset_id'] = None
+        else:
+            n['migration_note'] = None
+        out.append(n)
+    return out
+
+
+def node_to_row(node):
+    def _dt(unix):
+        return datetime.fromtimestamp(unix, tz=timezone.utc).replace(tzinfo=None)
+    return {'dataset_id': node['dataset_id'],
+            'title': node['title'],
+            'body': node['body'] or '',
+            'portals': node['portals'] or '',
+            'published': int(node['status']),
+            'drupal_nid': node['nid'],
+            'drupal_author': node['author'],
+            'migration_note': node['migration_note'],
+            'created_at': _dt(node['created']),
+            'updated_at': _dt(node['changed'])}
+
+
+def run_migration(engine, s3_client, bucket, dry_run=False, skip_assets=False):
+    rows = [node_to_row(n) for n in dedup_nodes(fetch_drupal_nodes())]
+    report = {'nodes': len(rows),
+              'published': sum(r['published'] for r in rows),
+              'no_dataset_id': sum(1 for r in rows if r['dataset_id'] is None),
+              'demoted_duplicates': sum(1 for r in rows if r['migration_note']),
+              'registry_links': 0, 'cms_rows_deleted': 0,
+              'assets': {'mirrored': 0, 'absent': [], 'errors': []}}
+    if dry_run:
+        return report
+    for r in rows:
+        kq.upsert_kp_dataset(engine, r)
+    report['registry_links'] = kq.backfill_registry_links(engine)
+    report['cms_rows_deleted'] = kq.delete_cms_datasetinfo_rows(engine)
+    if not skip_assets:
+        with engine.connect() as con:
+            bodies = con.execute(text("SELECT id, body FROM kp_datasets")).fetchall()
+        urls = set()
+        for _, body in bodies:
+            urls |= find_asset_urls(body)
+        report['assets'] = mirror_assets(urls, engine, s3_client, bucket)
+        with engine.begin() as con:
+            for row_id, body in bodies:
+                new = rewrite_asset_urls(body)
+                if new != body:
+                    con.execute(text("UPDATE kp_datasets SET body = :b WHERE id = :i"),
+                                {'b': new, 'i': row_id})
+    return report
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--bucket', default=None,
+                    help='defaults to KPN_CMS_ASSETS_BUCKET / dig-kpn-cms-assets')
+    ap.add_argument('--dry-run', action='store_true')
+    ap.add_argument('--skip-assets', action='store_true')
+    args = ap.parse_args()
+    engine = DataRegistryReadWriteDB().get_engine()
+    report = run_migration(engine, boto3.client('s3'), args.bucket or ASSETS_BUCKET,
+                           dry_run=args.dry_run, skip_assets=args.skip_assets)
+    json.dump(report, sys.stdout, indent=2)
+    print()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/migrate_kp_datasets.py
+++ b/scripts/migrate_kp_datasets.py
@@ -7,6 +7,10 @@ rows to existing registry datasets by exact name, deletes the superseded
 cms_content_item datasetinfo snapshot, and mirrors/rewrites embedded kp4cd
 asset URLs. Spec: docs/superpowers/specs/2026-08-14-kp-datasets-migration-design.md
 
+Residual limitation: a node deleted in Drupal whose dataset_id is later
+claimed by a different node leaves a stale row holding the ID -- stale rows
+(drupal_nid no longer present in Drupal) are never revisited by this script.
+
     python -m scripts.migrate_kp_datasets --dry-run   # report only, no writes
     python -m scripts.migrate_kp_datasets
 """
@@ -84,7 +88,7 @@ def dedup_nodes(nodes):
 def node_to_row(node):
     def _dt(unix):
         return datetime.fromtimestamp(unix, tz=timezone.utc).replace(tzinfo=None)
-    return {'dataset_id': node['dataset_id'],
+    return {'dataset_id': node['dataset_id'] or None,
             'title': node['title'],
             'body': node['body'] or '',
             'portals': node['portals'] or '',
@@ -106,7 +110,12 @@ def run_migration(engine, s3_client, bucket, dry_run=False, skip_assets=False):
               'assets': {'mirrored': 0, 'absent': [], 'errors': []}}
     if dry_run:
         return report
-    for r in rows:
+    # NULL-dataset_id rows first: when a duplicate-ID winner flips between
+    # runs, the demoted row must release the ID (via its drupal_nid match)
+    # before the new winner claims it -- otherwise the winner's upsert
+    # matches the OLD holder through the dataset_id unique key and lands on
+    # the wrong row.
+    for r in sorted(rows, key=lambda r: r['dataset_id'] is not None):
         kq.upsert_kp_dataset(engine, r)
     report['registry_links'] = kq.backfill_registry_links(engine)
     report['cms_rows_deleted'] = kq.delete_cms_datasetinfo_rows(engine)
@@ -131,7 +140,9 @@ def main():
     ap.add_argument('--bucket', default=None,
                     help='defaults to KPN_CMS_ASSETS_BUCKET / dig-kpn-cms-assets')
     ap.add_argument('--dry-run', action='store_true')
-    ap.add_argument('--skip-assets', action='store_true')
+    ap.add_argument('--skip-assets', action='store_true',
+                    help='skip asset mirroring/rewrite (test/dev only; a '
+                         're-run with this flag leaves raw kp4cd URLs in bodies)')
     args = ap.parse_args()
     engine = DataRegistryReadWriteDB().get_engine()
     report = run_migration(engine, boto3.client('s3'), args.bucket or ASSETS_BUCKET,

--- a/scripts/migrate_kp_datasets.py
+++ b/scripts/migrate_kp_datasets.py
@@ -58,11 +58,14 @@ def fetch_drupal_nodes():
 
 def dedup_nodes(nodes):
     """Latest-changed node keeps a duplicated dataset_id; earlier twins are
-    kept but demoted to dataset_id NULL with an explanatory note."""
+    kept but demoted to dataset_id NULL with an explanatory note. On equal
+    changed timestamps, the higher nid wins (deterministic tiebreak)."""
     winners = {}
     for n in nodes:
         ds = n['dataset_id']
-        if ds and (ds not in winners or n['changed'] > winners[ds]['changed']):
+        if ds and (ds not in winners
+                   or n['changed'] > winners[ds]['changed']
+                   or (n['changed'] == winners[ds]['changed'] and n['nid'] > winners[ds]['nid'])):
             winners[ds] = n
     out = []
     for n in nodes:

--- a/tests/kpn_cms/test_endpoints.py
+++ b/tests/kpn_cms/test_endpoints.py
@@ -95,7 +95,6 @@ def test_portal_view_fidelity(monkeypatch, view, fixture):
 # dead/empty in production (404 / [] everywhere, same MANIFEST evidence).
 @pytest.mark.parametrize('view,fixture,param,key', [
     ('static_content', 'static_content_apis.json', 'field_page', 'apis'),
-    ('datasetinfo', 'datasetinfo_sample.json', 'datasetid', 'Small2025_AorticStenosis'),
     ('paperheadermenu', 'paperheadermenu_sample.json', 'paper', 'apol1_portal'),
     ('eglmethod', 'eglmethod_sample.json', 'from', 'cardiogram'),
 ])
@@ -232,3 +231,71 @@ def test_misses_route_absent():
     # now, it must not expose the miss log.
     resp = client.get('/api/kpn/misses')
     assert 'hit_count' not in resp.text
+
+
+# --- datasetinfo: served from kp_datasets, not the cms_content_item snapshot ---
+
+from datetime import datetime
+
+from dataregistry.api import kp_datasets_query as kq
+
+
+def _kp_row(nid, dataset_id, published=1, portals='md, a2f',
+            updated=datetime(2024, 6, 1)):
+    return {'dataset_id': dataset_id, 'title': f'title {nid}',
+            'body': '<h3>Experiment summary</h3><p>s</p>', 'portals': portals,
+            'published': published, 'drupal_nid': nid,
+            'drupal_author': 'a@broadinstitute.org', 'migration_note': None,
+            'created_at': datetime(2024, 1, 1), 'updated_at': updated}
+
+
+def _clean_kp():
+    with engine.connect() as con:
+        con.execute(text("TRUNCATE TABLE kp_datasets"))
+        con.commit()
+
+
+def test_datasetinfo_keyed_hit_returns_envelope():
+    _clean(); _clean_kp()
+    kq.upsert_kp_dataset(engine, _kp_row(1704, 'Satoshi2024_TGtoHDL_EU'))
+    rows = client.get('/api/kpn/rest/views/datasetinfo',
+                      params={'datasetid': 'Satoshi2024_TGtoHDL_EU'}).json()
+    assert len(rows) == 1
+    assert rows[0]['field_dataset_id'] == [{'value': 'Satoshi2024_TGtoHDL_EU'}]
+    assert rows[0]['nid'] == [{'value': 1704}]
+    assert rows[0]['body'][0]['format'] == 'full_html'
+
+
+@responses.activate
+def test_datasetinfo_miss_returns_empty_without_proxy_or_miss_record():
+    # responses.activate with nothing registered: any outbound HTTP would blow
+    # up, so a clean [] proves the proxy path was never entered.
+    _clean(); _clean_kp()
+    rows = client.get('/api/kpn/rest/views/datasetinfo',
+                      params={'datasetid': 'Nope2020_X'}).json()
+    assert rows == []
+    with engine.connect() as con:
+        n = con.execute(text("SELECT COUNT(*) FROM cms_request_miss")).fetchone()[0]
+    assert n == 0
+
+
+def test_datasetinfo_unpublished_not_served():
+    _clean(); _clean_kp()
+    kq.upsert_kp_dataset(engine, _kp_row(1, 'Hidden2020_X', published=0))
+    assert client.get('/api/kpn/rest/views/datasetinfo',
+                      params={'datasetid': 'Hidden2020_X'}).json() == []
+    listing = client.get('/api/kpn/rest/views/datasetinfo').json()
+    assert 'Hidden2020_X' not in [r['field_dataset_id'][0]['value'] for r in listing if r['field_dataset_id']]
+
+
+def test_datasetinfo_listing_caps_at_10_newest_first_with_portal_filter():
+    _clean(); _clean_kp()
+    for i in range(12):
+        kq.upsert_kp_dataset(engine, _kp_row(300 + i, f'DS{i}_X',
+                                             portals='md, a2f' if i % 2 else 'cvd',
+                                             updated=datetime(2024, 1, 1 + i)))
+    listing = client.get('/api/kpn/rest/views/datasetinfo').json()
+    assert len(listing) == 10
+    assert listing[0]['field_dataset_id'] == [{'value': 'DS11_X'}]
+    md = client.get('/api/kpn/rest/views/datasetinfo', params={'portal': 'md'}).json()
+    assert {r['field_dataset_id'][0]['value'] for r in md} == {f'DS{i}_X' for i in (1, 3, 5, 7, 9, 11)}

--- a/tests/kpn_cms/test_import.py
+++ b/tests/kpn_cms/test_import.py
@@ -41,7 +41,6 @@ def _register(portals=('md',)):
     responses.get(f'{SRC}/rest/views/kpdatasets', status=404)
     responses.get(f'{SRC}/rest/views/a2f_community_kps', json=_fixture('a2f_community_kps.json'))
     responses.get(f'{SRC}/rest/views/help_book', json=_fixture('help_book.json'))
-    responses.get(f'{SRC}/rest/views/datasetinfo', json=_fixture('datasetinfo_sample.json'))
     responses.get(f'{SRC}/rest/views/content_by_id', json=_fixture('content_by_id_sample.json'))
     responses.get(f'{SRC}/egldata/dataset', status=404)
     responses.get(f'{SRC}/egldata/config', status=404)
@@ -73,14 +72,8 @@ def test_run_import_fills_all_views_and_harvests_nids():
     news_nids = {r['nid'] for r in _fixture('news2vueportal_md.json') if r.get('nid')}
     for nid in news_nids:
         assert q.get_view_rows(engine, 'content_by_id', nid=nid)
-    # datasetinfo keyed rows harvested via the portal-listing call.
-    # field_dataset_id arrives in Drupal's full-entity field format
-    # ([{"value": "..."}]) rather than a flat scalar -- unwrap it the same
-    # way the import pipeline does before using it as a lookup key.
-    raw_ds_id = _fixture('datasetinfo_sample.json')[0].get('field_dataset_id')
-    ds_id = raw_ds_id[0]['value'] if isinstance(raw_ds_id, list) and raw_ds_id else raw_ds_id
-    if ds_id:
-        assert q.get_view_rows(engine, 'datasetinfo', item_key=ds_id)
+    # datasetinfo is no longer imported -- kp_datasets is its system of record
+    assert q.get_view_rows(engine, 'datasetinfo') == []
     # dead/empty production views import as zero rows without failing the run
     assert report['views'].get('kpdatasets', 0) == 0
     assert report['views'].get('newresources', 0) == 0

--- a/tests/kpn_cms/test_kp_datasets_envelope.py
+++ b/tests/kpn_cms/test_kp_datasets_envelope.py
@@ -1,0 +1,55 @@
+import json
+import pathlib
+from datetime import datetime
+
+from dataregistry.api.kp_datasets_envelope import node_envelope
+
+FIX = pathlib.Path(__file__).parent / 'fixtures'
+
+
+def _row(**over):
+    row = {'id': 7, 'drupal_nid': 1721, 'dataset_id': 'Small2025_AorticStenosis',
+           'title': 'Calcific Aortic Stenosis 2025 GWAS', 'body': '<h3>Publication</h3><p>x</p>',
+           'portals': 'md, t2d, a2f', 'published': 1,
+           'created_at': datetime(2025, 10, 10, 13, 46, 5),
+           'updated_at': datetime(2025, 10, 16, 21, 36, 58)}
+    row.update(over)
+    return row
+
+
+def test_envelope_matches_live_fixture_shape():
+    fixture = json.loads((FIX / 'datasetinfo_sample.json').read_text())[0]
+    env = node_envelope(_row())
+    assert set(env) == set(fixture)
+    for field, items in fixture.items():
+        assert isinstance(env[field], list)
+        if items and env[field]:
+            assert set(env[field][0]) == set(items[0]), field
+
+
+def test_envelope_carries_authored_values():
+    env = node_envelope(_row())
+    assert env['nid'] == [{'value': 1721}]
+    assert env['title'] == [{'value': 'Calcific Aortic Stenosis 2025 GWAS'}]
+    assert env['field_dataset_id'] == [{'value': 'Small2025_AorticStenosis'}]
+    assert env['field_portals'] == [{'value': 'md, t2d, a2f'}]
+    assert env['status'] == [{'value': True}]
+    assert env['body'][0]['value'] == '<h3>Publication</h3><p>x</p>'
+    assert env['body'][0]['format'] == 'full_html'
+    assert env['created'][0] == {'value': '2025-10-10T13:46:05+00:00',
+                                 'format': 'Y-m-d\\TH:i:sP'}
+    assert env['changed'][0]['value'] == '2025-10-16T21:36:58+00:00'
+
+
+def test_envelope_is_deterministic():
+    assert node_envelope(_row()) == node_envelope(_row())
+
+
+def test_synthetic_nid_for_post_drupal_rows():
+    env = node_envelope(_row(drupal_nid=None, id=42))
+    assert env['nid'] == [{'value': 100042}]
+    assert env['vid'] == [{'value': 100042}]
+
+
+def test_missing_dataset_id_yields_empty_field():
+    assert node_envelope(_row(dataset_id=None))['field_dataset_id'] == []

--- a/tests/kpn_cms/test_kp_datasets_query.py
+++ b/tests/kpn_cms/test_kp_datasets_query.py
@@ -1,0 +1,114 @@
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from dataregistry.api.db import DataRegistryReadWriteDB
+from dataregistry.api import kp_datasets_query as kq
+from dataregistry.api import kpn_cms_query as q
+
+engine = DataRegistryReadWriteDB().get_engine()
+
+
+def _clean():
+    with engine.begin() as con:
+        con.execute(text("SET FOREIGN_KEY_CHECKS = 0"))
+        con.execute(text("TRUNCATE TABLE kp_datasets"))
+        con.execute(text("TRUNCATE TABLE cms_content_item"))
+        con.execute(text("DELETE FROM datasets WHERE name LIKE 'KPTEST_%'"))
+        con.execute(text("SET FOREIGN_KEY_CHECKS = 1"))
+
+
+def _row(nid, dataset_id=None, title='T', body='<p>b</p>', portals='md, a2f',
+         published=1, note=None, updated=datetime(2024, 6, 1)):
+    return {'dataset_id': dataset_id, 'title': title, 'body': body,
+            'portals': portals, 'published': published, 'drupal_nid': nid,
+            'drupal_author': 'a@broadinstitute.org', 'migration_note': note,
+            'created_at': datetime(2024, 1, 1), 'updated_at': updated}
+
+
+def _mk_registry_dataset(name):
+    ds_id = uuid.uuid4().hex.encode()
+    study_id = uuid.uuid4().hex.encode()
+    with engine.begin() as con:
+        # Create study first to satisfy foreign key constraint
+        con.execute(text("""
+            INSERT INTO studies (id, name, institution, created_at)
+            VALUES (:id, :study_name, :inst, NOW())
+        """), {'id': study_id, 'study_name': f'study_{study_id.decode()[:8]}', 'inst': 'test'})
+        con.execute(text("""
+            INSERT INTO datasets (id, name, data_source_type, data_type, genome_build,
+                ancestry, sex, global_sample_size, status, data_submitter,
+                data_submitter_email, data_contributor, data_contributor_email,
+                study_id, description, created_at, publicly_available, user_id)
+            VALUES (:id, :name, 'file', 'gwas', 'grch38', 'EU', 'mixed', 100, 'open',
+                's', 's@x.org', 'c', 'c@x.org', :sid, 'desc', NOW(), 1, 1)
+        """), {'id': ds_id, 'name': name, 'sid': study_id})
+    return ds_id
+
+
+def test_upsert_is_idempotent_by_drupal_nid():
+    _clean()
+    kq.upsert_kp_dataset(engine, _row(1703, dataset_id='KPTEST_A', title='old'))
+    kq.upsert_kp_dataset(engine, _row(1703, dataset_id='KPTEST_A', title='new'))
+    with engine.connect() as con:
+        n = con.execute(text("SELECT COUNT(*) FROM kp_datasets")).scalar()
+    assert n == 1
+    assert kq.get_by_dataset_id(engine, 'KPTEST_A')['title'] == 'new'
+
+
+def test_get_by_dataset_id_respects_published_flag():
+    _clean()
+    kq.upsert_kp_dataset(engine, _row(1, dataset_id='KPTEST_UNPUB', published=0))
+    assert kq.get_by_dataset_id(engine, 'KPTEST_UNPUB') is None
+    assert kq.get_by_dataset_id(engine, 'KPTEST_UNPUB', published_only=False)['drupal_nid'] == 1
+
+
+def test_list_recent_orders_caps_and_excludes_unpublished():
+    _clean()
+    for i in range(12):
+        kq.upsert_kp_dataset(engine, _row(100 + i, dataset_id=f'KPTEST_{i}',
+                                          updated=datetime(2024, 1, 1 + i)))
+    kq.upsert_kp_dataset(engine, _row(200, dataset_id='KPTEST_HIDDEN',
+                                      published=0, updated=datetime(2025, 1, 1)))
+    got = kq.list_recent(engine)
+    assert len(got) == 10
+    assert got[0]['dataset_id'] == 'KPTEST_11'          # newest first
+    assert all(r['published'] for r in got)
+
+
+def test_list_recent_portal_filter_is_token_exact():
+    _clean()
+    kq.upsert_kp_dataset(engine, _row(1, dataset_id='KPTEST_MD', portals='md, a2f'))
+    kq.upsert_kp_dataset(engine, _row(2, dataset_id='KPTEST_MDEP', portals='mdep, a2f'))
+    got = kq.list_recent(engine, portal='md')
+    assert [r['dataset_id'] for r in got] == ['KPTEST_MD']   # 'mdep' must not match
+
+
+def test_backfill_links_exact_name_matches_only():
+    _clean()
+    exact_id = _mk_registry_dataset('KPTEST_Exact')
+    _mk_registry_dataset('KPTEST_lower')
+    kq.upsert_kp_dataset(engine, _row(1, dataset_id='KPTEST_Exact'))
+    kq.upsert_kp_dataset(engine, _row(2, dataset_id='KPTEST_LOWER'))  # case differs
+    kq.upsert_kp_dataset(engine, _row(3, dataset_id='KPTEST_Missing'))
+    assert kq.backfill_registry_links(engine) == 1
+    assert kq.get_by_dataset_id(engine, 'KPTEST_Exact')['registry_dataset_id'] == exact_id
+    assert kq.get_by_dataset_id(engine, 'KPTEST_LOWER')['registry_dataset_id'] is None
+    assert kq.get_by_dataset_id(engine, 'KPTEST_Missing')['registry_dataset_id'] is None
+
+
+def test_delete_cms_datasetinfo_rows_leaves_other_views():
+    _clean()
+    q.replace_view_rows(engine, 'datasetinfo', 'item_key', 'X',
+                        [{'view_name': 'datasetinfo', 'portal': None, 'nid': None,
+                          'item_key': 'X', 'payload': '{}', 'search_text': None,
+                          'sort_order': 0}])
+    q.replace_view_rows(engine, 'help_book', None, None,
+                        [{'view_name': 'help_book', 'portal': None, 'nid': None,
+                          'item_key': None, 'payload': '{}', 'search_text': None,
+                          'sort_order': 0}])
+    assert kq.delete_cms_datasetinfo_rows(engine) == 1
+    assert q.get_view_rows(engine, 'datasetinfo') == []
+    assert q.get_view_rows(engine, 'help_book') == [{}]

--- a/tests/kpn_cms/test_kp_datasets_query.py
+++ b/tests/kpn_cms/test_kp_datasets_query.py
@@ -1,7 +1,6 @@
 import uuid
 from datetime import datetime
 
-import pytest
 from sqlalchemy import text
 
 from dataregistry.api.db import DataRegistryReadWriteDB

--- a/tests/kpn_cms/test_migrate_kp_datasets.py
+++ b/tests/kpn_cms/test_migrate_kp_datasets.py
@@ -118,3 +118,41 @@ def test_run_migration_mirrors_and_rewrites_body_assets(monkeypatch):
     stored = kq.get_by_dataset_id(engine, 'ASSETTEST_A')['body']
     assert '/api/kpn/files/pic.png' in stored and 'kp4cd.org' not in stored
     s3.head_object(Bucket='kpn-cms-test', Key='kpn-cms-assets/pic.png')
+
+
+@mock_aws
+def test_run_migration_winner_flip_rerun_does_not_lose_dataset(monkeypatch):
+    """Regression: when a duplicate-dataset_id winner flips between runs,
+    the new winner's upsert must not land on the old holder's row via the
+    dataset_id unique key. NULL-dataset_id rows must be upserted first so
+    the demoted row releases the id before the new winner claims it."""
+    _clean()
+    s3 = boto3.client('s3', region_name='us-east-1'); s3.create_bucket(Bucket='kpn-cms-test')
+
+    # First run: nid 1 holds FLIP_X; nid 2 has no competing dataset_id.
+    monkeypatch.setattr(mig, 'fetch_drupal_nodes',
+                        lambda: [_node(1, 'FLIP_X', changed=100), _node(2, None, changed=90)])
+    mig.run_migration(engine, s3, 'kpn-cms-test', skip_assets=True)
+    assert kq.get_by_dataset_id(engine, 'FLIP_X')['drupal_nid'] == 1
+
+    # Second run: both nodes now claim FLIP_X. nid 2's later `changed` makes
+    # it the new winner and nid 1 gets demoted to dataset_id NULL. The stub
+    # returns the winner FIRST (the pathological order) to prove the sort
+    # -- not incidental SELECT order -- is what saves the migration.
+    monkeypatch.setattr(mig, 'fetch_drupal_nodes',
+                        lambda: [_node(2, 'FLIP_X', changed=200), _node(1, 'FLIP_X', changed=100)])
+    mig.run_migration(engine, s3, 'kpn-cms-test', skip_assets=True)
+
+    winner = kq.get_by_dataset_id(engine, 'FLIP_X')
+    assert winner is not None
+    assert winner['drupal_nid'] == 2
+    assert winner['title'] == 't2'
+
+    with engine.connect() as con:
+        demoted = con.execute(text(
+            "SELECT * FROM kp_datasets WHERE drupal_nid = 1")).mappings().fetchone()
+        total = con.execute(text("SELECT COUNT(*) FROM kp_datasets")).scalar()
+    assert demoted is not None
+    assert demoted['dataset_id'] is None
+    assert demoted['migration_note'] == 'duplicate dataset_id FLIP_X; superseded by nid 2'
+    assert total == 2

--- a/tests/kpn_cms/test_migrate_kp_datasets.py
+++ b/tests/kpn_cms/test_migrate_kp_datasets.py
@@ -41,6 +41,28 @@ def test_dedup_latest_changed_wins():
     assert out[4]['dataset_id'] is None and out[4]['migration_note'] is None
 
 
+def test_dedup_ties_break_on_higher_nid():
+    """On equal changed timestamp, higher nid wins (deterministic tiebreak)."""
+    # Test both orderings to verify deterministic result regardless of input order
+    nodes_asc = [_node(1, 'TIE_A', changed=500), _node(3, 'TIE_A', changed=500),
+                 _node(2, 'TIE_A', changed=500)]
+    nodes_desc = [_node(3, 'TIE_A', changed=500), _node(2, 'TIE_A', changed=500),
+                  _node(1, 'TIE_A', changed=500)]
+
+    # Both orderings should produce the same result: nid 3 wins
+    for nodes in [nodes_asc, nodes_desc]:
+        out = {n['nid']: n for n in mig.dedup_nodes(nodes)}
+        assert len(out) == 3
+        # nid 3 (highest) keeps the dataset_id with no note
+        assert out[3]['dataset_id'] == 'TIE_A' and out[3]['migration_note'] is None
+        # nid 2 (middle) is demoted
+        assert out[2]['dataset_id'] is None
+        assert out[2]['migration_note'] == 'duplicate dataset_id TIE_A; superseded by nid 3'
+        # nid 1 (lowest) is also demoted
+        assert out[1]['dataset_id'] is None
+        assert out[1]['migration_note'] == 'duplicate dataset_id TIE_A; superseded by nid 3'
+
+
 def test_node_to_row_converts_types_and_defaults():
     node = dict(_node(9, 'A_B'), migration_note=None, body=None, portals=None)
     row = mig.node_to_row(node)

--- a/tests/kpn_cms/test_migrate_kp_datasets.py
+++ b/tests/kpn_cms/test_migrate_kp_datasets.py
@@ -1,0 +1,98 @@
+from datetime import datetime
+
+import boto3
+import responses
+from moto import mock_aws
+from sqlalchemy import text
+
+from dataregistry.api.db import DataRegistryReadWriteDB
+from dataregistry.api import kp_datasets_query as kq
+from dataregistry.api import kpn_cms_query as q
+from scripts import migrate_kp_datasets as mig
+
+engine = DataRegistryReadWriteDB().get_engine()
+
+
+def _clean():
+    with engine.connect() as con:
+        con.execute(text("TRUNCATE TABLE kp_datasets"))
+        con.execute(text("TRUNCATE TABLE cms_content_item"))
+        con.execute(text("TRUNCATE TABLE cms_asset"))
+        con.commit()
+
+
+def _node(nid, dataset_id, changed=1700000000, status=1, body='<p>b</p>',
+          portals='md, a2f'):
+    return {'nid': nid, 'title': f't{nid}', 'status': status,
+            'created': 1600000000, 'changed': changed,
+            'author': 'mariacos@broadinstitute.org',
+            'dataset_id': dataset_id, 'portals': portals, 'body': body}
+
+
+def test_dedup_latest_changed_wins():
+    nodes = [_node(1, 'DUP_X', changed=100), _node(2, 'DUP_X', changed=200),
+             _node(3, 'SOLO_Y', changed=50), _node(4, None, changed=60)]
+    out = {n['nid']: n for n in mig.dedup_nodes(nodes)}
+    assert len(out) == 4
+    assert out[2]['dataset_id'] == 'DUP_X' and out[2]['migration_note'] is None
+    assert out[1]['dataset_id'] is None
+    assert out[1]['migration_note'] == 'duplicate dataset_id DUP_X; superseded by nid 2'
+    assert out[3]['dataset_id'] == 'SOLO_Y' and out[3]['migration_note'] is None
+    assert out[4]['dataset_id'] is None and out[4]['migration_note'] is None
+
+
+def test_node_to_row_converts_types_and_defaults():
+    node = dict(_node(9, 'A_B'), migration_note=None, body=None, portals=None)
+    row = mig.node_to_row(node)
+    assert row['body'] == '' and row['portals'] == ''
+    assert row['published'] == 1 and row['drupal_nid'] == 9
+    assert row['created_at'] == datetime(2020, 9, 13, 12, 26, 40)
+    assert row['updated_at'] == datetime(2023, 11, 14, 22, 13, 20)
+
+
+@mock_aws
+def test_run_migration_upserts_links_and_cleans_cms(monkeypatch):
+    _clean()
+    monkeypatch.setattr(mig, 'fetch_drupal_nodes',
+                        lambda: [_node(1, 'MIGTEST_A'), _node(2, 'MIGTEST_B', status=0)])
+    q.replace_view_rows(engine, 'datasetinfo', 'item_key', 'old',
+                        [{'view_name': 'datasetinfo', 'portal': None, 'nid': None,
+                          'item_key': 'old', 'payload': '{}', 'search_text': None,
+                          'sort_order': 0}])
+    s3 = boto3.client('s3', region_name='us-east-1'); s3.create_bucket(Bucket='kpn-cms-test')
+    report = mig.run_migration(engine, s3, 'kpn-cms-test', skip_assets=True)
+    assert report['nodes'] == 2 and report['published'] == 1
+    assert report['cms_rows_deleted'] == 1
+    assert kq.get_by_dataset_id(engine, 'MIGTEST_A')['title'] == 't1'
+    # idempotent: run again, same row count
+    mig.run_migration(engine, s3, 'kpn-cms-test', skip_assets=True)
+    with engine.connect() as con:
+        assert con.execute(text("SELECT COUNT(*) FROM kp_datasets")).scalar() == 2
+
+
+@mock_aws
+def test_run_migration_dry_run_writes_nothing(monkeypatch):
+    _clean()
+    monkeypatch.setattr(mig, 'fetch_drupal_nodes', lambda: [_node(1, 'DRYTEST_A')])
+    s3 = boto3.client('s3', region_name='us-east-1'); s3.create_bucket(Bucket='kpn-cms-test')
+    report = mig.run_migration(engine, s3, 'kpn-cms-test', dry_run=True)
+    assert report['nodes'] == 1
+    with engine.connect() as con:
+        assert con.execute(text("SELECT COUNT(*) FROM kp_datasets")).scalar() == 0
+
+
+@mock_aws
+@responses.activate
+def test_run_migration_mirrors_and_rewrites_body_assets(monkeypatch):
+    _clean()
+    body = '<img src="https://kp4cd.org/sites/default/files/pic.png">'
+    monkeypatch.setattr(mig, 'fetch_drupal_nodes',
+                        lambda: [_node(1, 'ASSETTEST_A', body=body)])
+    responses.get('https://kp4cd.org/sites/default/files/pic.png', body=b'png',
+                  content_type='image/png')
+    s3 = boto3.client('s3', region_name='us-east-1'); s3.create_bucket(Bucket='kpn-cms-test')
+    report = mig.run_migration(engine, s3, 'kpn-cms-test')
+    assert report['assets']['mirrored'] == 1
+    stored = kq.get_by_dataset_id(engine, 'ASSETTEST_A')['body']
+    assert '/api/kpn/files/pic.png' in stored and 'kp4cd.org' not in stored
+    s3.head_object(Bucket='kpn-cms-test', Key='kpn-cms-assets/pic.png')

--- a/tests/kpn_cms/test_migration.py
+++ b/tests/kpn_cms/test_migration.py
@@ -26,3 +26,9 @@ def test_cms_asset_table():
 def test_cms_request_miss_table():
     assert {'id', 'view_name', 'query_string', 'proxied', 'response_status',
             'hit_count', 'first_seen', 'last_seen'} <= _columns('cms_request_miss')
+
+
+def test_kp_datasets_table():
+    assert {'id', 'dataset_id', 'title', 'body', 'portals', 'published',
+            'registry_dataset_id', 'drupal_nid', 'drupal_author',
+            'migration_note', 'created_at', 'updated_at'} <= _columns('kp_datasets')


### PR DESCRIPTION
## Summary

Makes a new `kp_datasets` table the system of record for portal-facing KP dataset info, replacing the Drupal-snapshot approach for the `datasetinfo` view (kp4cd.org retirement). The public Drupal REST view only ever exposed the 10 most-recently-updated datasets; the actual node base holds **1,047** `kp_dataset` nodes. This PR adds the table, the serving switch, and an idempotent migration script that reads the Drupal RDS directly.

- **`kp_datasets` table** (Alembic `create_kp_datasets`): normalized columns (dataset_id, title, body HTML, portals, published) + provenance (drupal_nid, author, created/changed) + nullable `registry_dataset_id` link to `datasets` (backfilled on exact name match — 60 expected).
- **Serving switch**: `GET /api/kpn/rest/views/datasetinfo` now synthesizes the exact Drupal node envelope (fixture-verified) from `kp_datasets`. Keyed lookups serve any published dataset; listing = 10 newest, portal filter honored token-exactly. No proxy-on-miss for this view anymore.
- **Migration script** `python -m scripts.migrate_kp_datasets`: SELECT-only read of the Drupal RDS via the `kp4cd-220214` secret; latest-wins dedup of the 3 duplicate dataset IDs (deterministic nid tiebreak); NULL-first upsert ordering so re-runs converge safely; deletes the superseded `cms_content_item` datasetinfo rows; mirrors and rewrites embedded kp4cd asset URLs. `--dry-run` supported; expected report: nodes 1047, published 1029, no_dataset_id 6, demoted_duplicates 3.
- **Import retirement**: the datasetinfo leg is removed from `scripts/import_kpn_cms.py`.

## Deploy ordering (important)

Merging triggers the CI deploy. Until `alembic upgrade head` and the migration script run against the target DB, `datasetinfo` serves `[]` (the new code ignores the old snapshot rows). Run the DB steps immediately around the deploy:

```
export DATA_REGISTRY_DB_CONNECTION=<target>   # deliberate; never rely on the default
alembic upgrade head
python -m scripts.migrate_kp_datasets --dry-run   # review counts first
python -m scripts.migrate_kp_datasets
```

## Test plan

- Full suite: **479 passed** (baseline before branch: 457) against the docker MySQL harness.
- New coverage: migration up, store ops (idempotent upsert, published filtering, ordering/cap, token-exact portal filter, BINARY exact-match backfill), envelope shape vs captured live fixture, endpoint behaviors (keyed hit/miss with no proxy and no miss-record, unpublished never served), dedup incl. tie + winner-flip re-run regression, dry-run purity, asset mirror/rewrite via moto+responses.
- QA verification checklist (post-merge): row counts (1047/1029/1041/~60), `cms_content_item` datasetinfo rows = 0, curl-diff QA vs live kp4cd for `Small2025_AorticStenosis` and `Satoshi2024_TGtoHDL_EU`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qkb5thQHx1NSGBRGv9rdAb