### PR TITLE
KP dataset info create/edit API (phase 2)

### DIFF
--- a/dataregistry/api/api.py
+++ b/dataregistry/api/api.py
@@ -22,7 +22,8 @@ from starlette.responses import StreamingResponse, Response, RedirectResponse
 from streaming_form_data import StreamingFormDataParser
 from streaming_form_data.targets import S3Target
 
-from dataregistry.api import query, s3, file_utils, ecs, bioidx, batch, liftover, portals
+from dataregistry.api import query, s3, file_utils, ecs, bioidx, batch, liftover, portals, kp_datasets_query
+from dataregistry.api.kp_datasets_body import compose_body
 from dataregistry.api.mskkp import suggest_column_map
 from dataregistry.api.db import DataRegistryReadWriteDB
 from dataregistry.api.google_oauth import get_google_user
@@ -31,7 +32,7 @@ from dataregistry.api.jwt_utils import get_encoded_jwt_data, get_decoded_jwt_dat
 from dataregistry.api.model import DataSet, Study, SavedDatasetInfo, SavedDataset, UserCredentials, User, SavedStudy, \
     CreateBiondexRequest, CsvBioIndexRequest, BioIndexCreationStatus, SavedCsvBioIndexRequest, HermesFileStatus, \
     HermesUploadStatus, NewUserRequest, StartAggregatorRequest, MetaAnalysisRequest, QCHermesFileRequest, \
-    QCScriptOptions, HermesPhenotype, FileType, PortalConfigUpdateRequest, GenomeBuild
+    QCScriptOptions, HermesPhenotype, FileType, PortalConfigUpdateRequest, GenomeBuild, KpDatasetInfo
 from dataregistry.api.phenotypes import get_phenotypes
 from dataregistry.api.validators import HermesValidator
 
@@ -432,6 +433,45 @@ async def get_hermes_pre_signed_url(request: Request):
 @router.get('/kp-portals', response_class=fastapi.responses.ORJSONResponse)
 async def kp_portals(user: User = Depends(get_current_user)):
     return portals.get_portals()
+
+
+@router.get('/kp-dataset-info/{dataset_id}', response_class=fastapi.responses.ORJSONResponse)
+async def get_kp_dataset_info(dataset_id: UUID, user: User = Depends(get_current_user)):
+    check_perms(str(dataset_id), user, "You don't have permission to this dataset")
+    row = kp_datasets_query.get_by_registry_dataset_id(engine, dataset_id.hex.encode())
+    if not row:
+        return None
+    return {'title': row['title'], 'body': row['body'], 'dataset_id': row['dataset_id'],
+            'portals': [p.strip() for p in row['portals'].split(',') if p.strip()]}
+
+
+@router.post('/kp-dataset-info', response_class=fastapi.responses.ORJSONResponse)
+async def save_kp_dataset_info(req: KpDatasetInfo, user: User = Depends(get_current_user)):
+    check_perms(str(req.dataset_id), user, "You do not have permission to update this dataset")
+    if not req.title.strip():
+        raise fastapi.HTTPException(status_code=422, detail='title is required')
+    valid = set(portals.get_portals())
+    bad = [p for p in req.portals if p not in valid]
+    if bad or not req.portals:
+        raise fastapi.HTTPException(status_code=422,
+                                    detail=f'invalid portals: {bad or "none selected"}')
+    try:
+        ds = query.get_dataset(engine, req.dataset_id)
+    except ValueError:
+        raise fastapi.HTTPException(status_code=404, detail='dataset not found')
+    phenos = query.get_phenotypes_for_dataset(engine, req.dataset_id)
+    lookup = get_phenotypes()
+    names = [lookup.get(p.phenotype, {}).get('description', p.phenotype) for p in phenos]
+    body = compose_body(ds.publication, names, req.experiment_summary)
+    try:
+        row_id = kp_datasets_query.upsert_portal_info(
+            engine, req.dataset_id.hex.encode(), ds.name, req.title.strip(),
+            ', '.join(req.portals), body)
+    except sqlalchemy.exc.IntegrityError:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail='A KP dataset entry with this dataset ID already exists')
+    return {'id': row_id, 'dataset_id': ds.name, 'body': body}
 
 
 @router.patch("/hermes-rerun-qc/{file_id}")

--- a/dataregistry/api/api.py
+++ b/dataregistry/api/api.py
@@ -22,7 +22,7 @@ from starlette.responses import StreamingResponse, Response, RedirectResponse
 from streaming_form_data import StreamingFormDataParser
 from streaming_form_data.targets import S3Target
 
-from dataregistry.api import query, s3, file_utils, ecs, bioidx, batch, liftover
+from dataregistry.api import query, s3, file_utils, ecs, bioidx, batch, liftover, portals
 from dataregistry.api.mskkp import suggest_column_map
 from dataregistry.api.db import DataRegistryReadWriteDB
 from dataregistry.api.google_oauth import get_google_user
@@ -427,6 +427,11 @@ async def get_hermes_pre_signed_url(request: Request):
     dataset = request.headers.get('Dataset')
     s3_path = f"hermes/{dataset}/{filename}"
     return s3.generate_presigned_url_with_path(s3_path)
+
+
+@router.get('/kp-portals', response_class=fastapi.responses.ORJSONResponse)
+async def kp_portals(user: User = Depends(get_current_user)):
+    return portals.get_portals()
 
 
 @router.patch("/hermes-rerun-qc/{file_id}")

--- a/dataregistry/api/api.py
+++ b/dataregistry/api/api.py
@@ -23,7 +23,7 @@ from streaming_form_data import StreamingFormDataParser
 from streaming_form_data.targets import S3Target
 
 from dataregistry.api import query, s3, file_utils, ecs, bioidx, batch, liftover, portals, kp_datasets_query
-from dataregistry.api.kp_datasets_body import compose_body
+from dataregistry.api.kp_datasets_body import compose_body, parse_experiment_summary
 from dataregistry.api.mskkp import suggest_column_map
 from dataregistry.api.db import DataRegistryReadWriteDB
 from dataregistry.api.google_oauth import get_google_user
@@ -442,7 +442,8 @@ async def get_kp_dataset_info(dataset_id: UUID, user: User = Depends(get_current
     if not row:
         return None
     return {'title': row['title'], 'body': row['body'], 'dataset_id': row['dataset_id'],
-            'portals': [p.strip() for p in row['portals'].split(',') if p.strip()]}
+            'portals': [p.strip() for p in row['portals'].split(',') if p.strip()],
+            'experiment_summary': parse_experiment_summary(row['body'])}
 
 
 @router.post('/kp-dataset-info', response_class=fastapi.responses.ORJSONResponse)
@@ -453,8 +454,10 @@ async def save_kp_dataset_info(req: KpDatasetInfo, user: User = Depends(get_curr
     valid = set(portals.get_portals())
     bad = [p for p in req.portals if p not in valid]
     if bad or not req.portals:
-        raise fastapi.HTTPException(status_code=422,
-                                    detail=f'invalid portals: {bad or "none selected"}')
+        raise fastapi.HTTPException(status_code=422, detail='invalid portals')
+    joined = ', '.join(req.portals)
+    if len(joined) > 500:
+        raise fastapi.HTTPException(status_code=422, detail='too many portals')
     try:
         ds = query.get_dataset(engine, req.dataset_id)
     except ValueError:
@@ -466,7 +469,7 @@ async def save_kp_dataset_info(req: KpDatasetInfo, user: User = Depends(get_curr
     try:
         row_id = kp_datasets_query.upsert_portal_info(
             engine, req.dataset_id.hex.encode(), ds.name, req.title.strip(),
-            ', '.join(req.portals), body)
+            joined, body)
     except sqlalchemy.exc.IntegrityError:
         raise fastapi.HTTPException(
             status_code=409,

--- a/dataregistry/api/kp_datasets_body.py
+++ b/dataregistry/api/kp_datasets_body.py
@@ -1,0 +1,18 @@
+"""Compose kp_datasets body HTML from structured inputs.
+
+Reproduces the section pattern the Drupal authors typed by hand
+(<h3>Publication</h3> / <h3>Phenotypes</h3> / <h3>Experiment summary</h3>)
+so generated and migrated bodies render identically on the portals.
+User-supplied text is HTML-escaped; migrated Drupal bodies are stored
+verbatim and never pass through here unless re-saved via the edit flow.
+"""
+import html
+
+
+def compose_body(publication, phenotype_names, experiment_summary):
+    pub = html.escape(publication) if publication else 'Unpublished'
+    items = ''.join(f'<li>{html.escape(p)}</li>' for p in phenotype_names)
+    summary = html.escape(experiment_summary or '')
+    return (f'<h3>Publication</h3><p>{pub}</p>'
+            f'<h3>Phenotypes</h3><ul>{items}</ul>'
+            f'<h3>Experiment summary</h3><p>{summary}</p>')

--- a/dataregistry/api/kp_datasets_body.py
+++ b/dataregistry/api/kp_datasets_body.py
@@ -7,6 +7,7 @@ User-supplied text is HTML-escaped; migrated Drupal bodies are stored
 verbatim and never pass through here unless re-saved via the edit flow.
 """
 import html
+import re
 
 
 def compose_body(publication, phenotype_names, experiment_summary):
@@ -16,3 +17,16 @@ def compose_body(publication, phenotype_names, experiment_summary):
     return (f'<h3>Publication</h3><p>{pub}</p>'
             f'<h3>Phenotypes</h3><ul>{items}</ul>'
             f'<h3>Experiment summary</h3><p>{summary}</p>')
+
+
+_GENERATED_RE = re.compile(
+    r'^<h3>Publication</h3><p>.*</p>'
+    r'<h3>Phenotypes</h3><ul>.*</ul>'
+    r'<h3>Experiment summary</h3><p>(.*)</p>$', re.DOTALL)
+
+
+def parse_experiment_summary(body):
+    """Extract the summary from a body THIS module generated; None for
+    hand-authored (migrated) bodies, which don't round-trip by design."""
+    m = _GENERATED_RE.match(body or '')
+    return html.unescape(m.group(1)) if m else None

--- a/dataregistry/api/kp_datasets_query.py
+++ b/dataregistry/api/kp_datasets_query.py
@@ -3,6 +3,7 @@ KP dataset info after the kp4cd.org migration.
 
 Spec: docs/superpowers/specs/2026-08-14-kp-datasets-migration-design.md
 """
+from datetime import datetime
 from sqlalchemy import text
 
 
@@ -64,3 +65,48 @@ def backfill_registry_links(engine) -> int:
             SET k.registry_dataset_id = d.id
         """))
     return res.rowcount
+
+
+def get_by_registry_dataset_id(engine, registry_dataset_id):
+    with engine.connect() as con:
+        r = con.execute(text(
+            "SELECT * FROM kp_datasets WHERE registry_dataset_id = :r"),
+            {'r': registry_dataset_id}).mappings().fetchone()
+    return dict(r) if r else None
+
+
+def upsert_portal_info(engine, registry_dataset_id, dataset_id, title, portals, body):
+    """Create or update the portal-display row for a registry dataset.
+
+    One KP row per registry dataset, keyed on registry_dataset_id. A
+    migrated row that already holds this dataset_id but has no registry
+    link yet is adopted (linked + updated) rather than colliding with the
+    dataset_id unique key. Timestamps are naive UTC -- node_envelope's
+    _ts() depends on that.
+    """
+    now = datetime.utcnow().replace(microsecond=0)
+    with engine.begin() as con:
+        row = con.execute(text(
+            "SELECT id FROM kp_datasets WHERE registry_dataset_id = :r"),
+            {'r': registry_dataset_id}).fetchone()
+        if row is None:
+            row = con.execute(text(
+                "SELECT id FROM kp_datasets WHERE dataset_id = :d "
+                "AND registry_dataset_id IS NULL"), {'d': dataset_id}).fetchone()
+        if row:
+            con.execute(text("""
+                UPDATE kp_datasets SET dataset_id = :d, title = :t, body = :b,
+                    portals = :p, published = 1, registry_dataset_id = :r,
+                    updated_at = :now
+                WHERE id = :i
+            """), {'d': dataset_id, 't': title, 'b': body, 'p': portals,
+                   'r': registry_dataset_id, 'now': now, 'i': row[0]})
+            return row[0]
+        res = con.execute(text("""
+            INSERT INTO kp_datasets
+                (dataset_id, title, body, portals, published,
+                 registry_dataset_id, created_at, updated_at)
+            VALUES (:d, :t, :b, :p, 1, :r, :now, :now)
+        """), {'d': dataset_id, 't': title, 'b': body, 'p': portals,
+               'r': registry_dataset_id, 'now': now})
+        return res.lastrowid

--- a/dataregistry/api/kp_datasets_query.py
+++ b/dataregistry/api/kp_datasets_query.py
@@ -91,7 +91,7 @@ def upsert_portal_info(engine, registry_dataset_id, dataset_id, title, portals, 
             {'r': registry_dataset_id}).fetchone()
         if row is None:
             row = con.execute(text(
-                "SELECT id FROM kp_datasets WHERE dataset_id = :d "
+                "SELECT id FROM kp_datasets WHERE BINARY dataset_id = :d "
                 "AND registry_dataset_id IS NULL"), {'d': dataset_id}).fetchone()
         if row:
             con.execute(text("""

--- a/dataregistry/api/model.py
+++ b/dataregistry/api/model.py
@@ -650,3 +650,10 @@ class HCMLiftoverJob(BaseModel):
     summary: Optional[dict] = None
 
 
+class KpDatasetInfo(BaseModel):
+    dataset_id: UUID
+    title: str
+    portals: List[str]
+    experiment_summary: str
+
+

--- a/dataregistry/api/model.py
+++ b/dataregistry/api/model.py
@@ -652,7 +652,7 @@ class HCMLiftoverJob(BaseModel):
 
 class KpDatasetInfo(BaseModel):
     dataset_id: UUID
-    title: str
+    title: str = Field(max_length=500)
     portals: List[str]
     experiment_summary: str
 

--- a/dataregistry/api/portals.py
+++ b/dataregistry/api/portals.py
@@ -1,0 +1,11 @@
+"""Cached bioindex portal-groups lookup (same pattern as phenotypes.get_phenotypes)."""
+from functools import lru_cache
+
+import requests
+
+
+@lru_cache
+def get_portals() -> list:
+    res = requests.get('https://bioindex.hugeamp.org/api/portal/groups', timeout=30)
+    res.raise_for_status()
+    return sorted(g['name'] for g in res.json()['data'])

--- a/tests/api/test_kp_dataset_info.py
+++ b/tests/api/test_kp_dataset_info.py
@@ -1,3 +1,5 @@
+import uuid
+
 import responses
 
 from dataregistry.api.jwt_utils import get_encoded_jwt_data
@@ -22,3 +24,93 @@ def test_kp_portals_requires_auth():
     from dataregistry.api import portals
     portals.get_portals.cache_clear()
     assert client.get('/api/kp-portals').status_code == 401
+
+
+def _mk_dataset():
+    study = client.post('/api/studies',
+                        json={'name': f'KPI Study {uuid.uuid4().hex[:8]}', 'institution': 'Broad'},
+                        headers=AUTH).json()
+    ds = client.post('/api/datasets', json={
+        'name': f'KPITEST_{uuid.uuid4().hex[:8]}', 'data_source_type': 'file',
+        'data_type': 'gwas', 'genome_build': 'grch38', 'ancestry': 'EU',
+        'data_submitter': 's', 'data_submitter_email': 's@x.org',
+        'data_contributor': 'c', 'data_contributor_email': 'c@x.org',
+        'sex': 'mixed', 'global_sample_size': 100, 'status': 'open',
+        'description': 'the description', 'study_id': study['id'].replace('-', ''),
+        'pub_id': None, 'publication': 'Big GWAS Paper 2026',
+        'publicly_available': True}, headers=AUTH).json()
+    return ds
+
+
+def _mock_bioindex():
+    from dataregistry.api import portals, phenotypes
+    portals.get_portals.cache_clear()
+    phenotypes.get_phenotypes.cache_clear()
+    responses.get('https://bioindex.hugeamp.org/api/portal/groups',
+                  json={'data': [{'name': 'md'}, {'name': 'a2f'}]})
+    responses.get('https://bioindex.hugeamp.org/api/portal/phenotypes',
+                  json={'data': [{'name': 'T2D', 'description': 'Type 2 diabetes',
+                                  'dichotomous': True}]})
+
+
+@responses.activate
+def test_get_info_returns_null_before_save_then_roundtrips():
+    _mock_bioindex()
+    ds = _mk_dataset()
+    assert client.get(f"/api/kp-dataset-info/{ds['id']}", headers=AUTH).json() is None
+    saved = client.post('/api/kp-dataset-info', json={
+        'dataset_id': ds['id'], 'title': 'My GWAS: European ancestry',
+        'portals': ['md', 'a2f'], 'experiment_summary': 'A GWAS of things.'},
+        headers=AUTH)
+    assert saved.status_code == 200
+    body = saved.json()['body']
+    assert '<h3>Publication</h3><p>Big GWAS Paper 2026</p>' in body
+    assert '<h3>Experiment summary</h3><p>A GWAS of things.</p>' in body
+    got = client.get(f"/api/kp-dataset-info/{ds['id']}", headers=AUTH).json()
+    assert got['title'] == 'My GWAS: European ancestry'
+    assert got['portals'] == ['md', 'a2f']
+    assert got['dataset_id'] == ds['name']
+
+
+@responses.activate
+def test_post_validates_title_and_portals():
+    _mock_bioindex()
+    ds = _mk_dataset()
+    base = {'dataset_id': ds['id'], 'title': 'T', 'portals': ['md'], 'experiment_summary': 's'}
+    assert client.post('/api/kp-dataset-info', json={**base, 'title': '  '},
+                       headers=AUTH).status_code == 422
+    assert client.post('/api/kp-dataset-info', json={**base, 'portals': []},
+                       headers=AUTH).status_code == 422
+    assert client.post('/api/kp-dataset-info', json={**base, 'portals': ['md', 'mskkp']},
+                       headers=AUTH).status_code == 422
+
+
+@responses.activate
+def test_saved_info_is_served_by_datasetinfo_endpoint():
+    _mock_bioindex()
+    ds = _mk_dataset()
+    client.post('/api/kp-dataset-info', json={
+        'dataset_id': ds['id'], 'title': 'Served Title', 'portals': ['md'],
+        'experiment_summary': 's'}, headers=AUTH)
+    rows = client.get('/api/kpn/rest/views/datasetinfo',
+                      params={'datasetid': ds['name']}).json()
+    assert rows and rows[0]['title'] == [{'value': 'Served Title'}]
+    assert rows[0]['field_portals'] == [{'value': 'md'}]
+
+
+@responses.activate
+def test_post_conflicts_when_name_collides_with_other_linked_row():
+    _mock_bioindex()
+    ds1 = _mk_dataset()
+    ds2 = _mk_dataset()
+    base = {'title': 'T', 'portals': ['md'], 'experiment_summary': 's'}
+    client.post('/api/kp-dataset-info', json={**base, 'dataset_id': ds1['id']}, headers=AUTH)
+    # rename ds2 to ds1's name via the DB is contrived; instead simulate the
+    # collision by saving info for ds2 after inserting a kp row that already
+    # holds ds2's name but is linked to a DIFFERENT registry id
+    from dataregistry.api.db import DataRegistryReadWriteDB
+    from dataregistry.api import kp_datasets_query as kq
+    engine2 = DataRegistryReadWriteDB().get_engine()
+    kq.upsert_portal_info(engine2, uuid.uuid4().hex.encode(), ds2['name'], 'other', 'md', '<p>b</p>')
+    resp = client.post('/api/kp-dataset-info', json={**base, 'dataset_id': ds2['id']}, headers=AUTH)
+    assert resp.status_code == 409

--- a/tests/api/test_kp_dataset_info.py
+++ b/tests/api/test_kp_dataset_info.py
@@ -1,0 +1,24 @@
+import responses
+
+from dataregistry.api.jwt_utils import get_encoded_jwt_data
+from dataregistry.api.model import User
+from tests.conftest import client
+
+AUTH = {'Authorization': f"Bearer {get_encoded_jwt_data(User(user_name='test', roles=['admin'], id=1))}"}
+
+
+@responses.activate
+def test_kp_portals_lists_bioindex_groups():
+    from dataregistry.api import portals
+    portals.get_portals.cache_clear()
+    responses.get('https://bioindex.hugeamp.org/api/portal/groups',
+                  json={'data': [{'name': 'md'}, {'name': 'a2f'}, {'name': 'cvd'}]})
+    resp = client.get('/api/kp-portals', headers=AUTH)
+    assert resp.status_code == 200
+    assert resp.json() == ['a2f', 'cvd', 'md']
+
+
+def test_kp_portals_requires_auth():
+    from dataregistry.api import portals
+    portals.get_portals.cache_clear()
+    assert client.get('/api/kp-portals').status_code == 401

--- a/tests/api/test_kp_dataset_info.py
+++ b/tests/api/test_kp_dataset_info.py
@@ -70,6 +70,7 @@ def test_get_info_returns_null_before_save_then_roundtrips():
     assert got['title'] == 'My GWAS: European ancestry'
     assert got['portals'] == ['md', 'a2f']
     assert got['dataset_id'] == ds['name']
+    assert got['experiment_summary'] == 'A GWAS of things.'
 
 
 @responses.activate
@@ -82,6 +83,8 @@ def test_post_validates_title_and_portals():
     assert client.post('/api/kp-dataset-info', json={**base, 'portals': []},
                        headers=AUTH).status_code == 422
     assert client.post('/api/kp-dataset-info', json={**base, 'portals': ['md', 'mskkp']},
+                       headers=AUTH).status_code == 422
+    assert client.post('/api/kp-dataset-info', json={**base, 'title': 'x' * 501},
                        headers=AUTH).status_code == 422
 
 

--- a/tests/kpn_cms/test_kp_datasets_body.py
+++ b/tests/kpn_cms/test_kp_datasets_body.py
@@ -1,4 +1,4 @@
-from dataregistry.api.kp_datasets_body import compose_body
+from dataregistry.api.kp_datasets_body import compose_body, parse_experiment_summary
 
 
 def test_matches_drupal_section_pattern():
@@ -27,3 +27,11 @@ def test_user_text_is_escaped():
     assert 'T2D &amp; obesity' in body
     assert 'a &lt; b' in body
     assert '<2024>' not in body
+
+
+def test_parse_experiment_summary_round_trips_generated_body():
+    assert parse_experiment_summary(compose_body('P & Q', ['A'], 'a < b')) == 'a < b'
+
+
+def test_parse_experiment_summary_returns_none_for_non_generated_body():
+    assert parse_experiment_summary('<h3>Data Links</h3><p>x</p>') is None

--- a/tests/kpn_cms/test_kp_datasets_body.py
+++ b/tests/kpn_cms/test_kp_datasets_body.py
@@ -1,0 +1,29 @@
+from dataregistry.api.kp_datasets_body import compose_body
+
+
+def test_matches_drupal_section_pattern():
+    body = compose_body('Unpublished', ['Triglyceride to HDL levels'],
+                        'This study conducted an East Asian ancestry GWAS of '
+                        'triglyceride to HDL levels in 3971 individuals.')
+    assert body == ('<h3>Publication</h3><p>Unpublished</p>'
+                    '<h3>Phenotypes</h3><ul><li>Triglyceride to HDL levels</li></ul>'
+                    '<h3>Experiment summary</h3><p>This study conducted an East Asian '
+                    'ancestry GWAS of triglyceride to HDL levels in 3971 individuals.</p>')
+
+
+def test_empty_publication_defaults_to_unpublished():
+    assert '<h3>Publication</h3><p>Unpublished</p>' in compose_body(None, [], 's')
+    assert '<h3>Publication</h3><p>Unpublished</p>' in compose_body('', [], 's')
+
+
+def test_multiple_phenotypes_and_empty_list():
+    assert '<ul><li>A</li><li>B</li></ul>' in compose_body(None, ['A', 'B'], 's')
+    assert '<ul></ul>' in compose_body(None, [], 's')
+
+
+def test_user_text_is_escaped():
+    body = compose_body('Smith & Jones <2024>', ['T2D & obesity'], 'a < b')
+    assert 'Smith &amp; Jones &lt;2024&gt;' in body
+    assert 'T2D &amp; obesity' in body
+    assert 'a &lt; b' in body
+    assert '<2024>' not in body

--- a/tests/kpn_cms/test_kp_datasets_query.py
+++ b/tests/kpn_cms/test_kp_datasets_query.py
@@ -123,6 +123,20 @@ def test_upsert_portal_info_adopts_unlinked_migrated_row():
         assert con.execute(text("SELECT COUNT(*) FROM kp_datasets")).scalar() == 1
 
 
+def test_upsert_portal_info_does_not_adopt_case_variant_row():
+    _clean()
+    kq.upsert_kp_dataset(engine, _row(1705, dataset_id='KPTEST_case', title='migrated'))
+    rid = uuid.uuid4().hex.encode()
+    import sqlalchemy
+    import pytest
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        # case-variant name must NOT adopt the migrated row; the INSERT then
+        # collides with the case-insensitive unique key and surfaces as a conflict
+        kq.upsert_portal_info(engine, rid, 'KPTEST_CASE', 'T', 'md', '<p>b</p>')
+    got = kq.get_by_dataset_id(engine, 'KPTEST_case', published_only=False)
+    assert got['title'] == 'migrated' and got['registry_dataset_id'] is None
+
+
 def test_upsert_portal_info_timestamps_are_naive_utc():
     _clean()
     rid = uuid.uuid4().hex.encode()

--- a/tests/kpn_cms/test_kp_datasets_query.py
+++ b/tests/kpn_cms/test_kp_datasets_query.py
@@ -94,3 +94,38 @@ def test_backfill_links_exact_name_matches_only():
     assert kq.get_by_dataset_id(engine, 'KPTEST_Exact')['registry_dataset_id'] == exact_id
     assert kq.get_by_dataset_id(engine, 'KPTEST_LOWER')['registry_dataset_id'] is None
     assert kq.get_by_dataset_id(engine, 'KPTEST_Missing')['registry_dataset_id'] is None
+
+
+def test_upsert_portal_info_creates_then_updates():
+    _clean()
+    rid = uuid.uuid4().hex.encode()
+    row_id = kq.upsert_portal_info(engine, rid, 'KPTEST_New', 'Title v1', 'md, a2f', '<p>b1</p>')
+    got = kq.get_by_registry_dataset_id(engine, rid)
+    assert got['id'] == row_id and got['title'] == 'Title v1' and got['published'] == 1
+    assert got['drupal_nid'] is None
+    row_id2 = kq.upsert_portal_info(engine, rid, 'KPTEST_New', 'Title v2', 'cvd', '<p>b2</p>')
+    assert row_id2 == row_id
+    got = kq.get_by_registry_dataset_id(engine, rid)
+    assert got['title'] == 'Title v2' and got['portals'] == 'cvd' and got['body'] == '<p>b2</p>'
+    with engine.connect() as con:
+        assert con.execute(text("SELECT COUNT(*) FROM kp_datasets")).scalar() == 1
+
+
+def test_upsert_portal_info_adopts_unlinked_migrated_row():
+    _clean()
+    kq.upsert_kp_dataset(engine, _row(1704, dataset_id='KPTEST_Migrated', title='old drupal'))
+    rid = uuid.uuid4().hex.encode()
+    row_id = kq.upsert_portal_info(engine, rid, 'KPTEST_Migrated', 'new title', 'md', '<p>new</p>')
+    got = kq.get_by_registry_dataset_id(engine, rid)
+    assert got['id'] == row_id and got['drupal_nid'] == 1704
+    assert got['title'] == 'new title'
+    with engine.connect() as con:
+        assert con.execute(text("SELECT COUNT(*) FROM kp_datasets")).scalar() == 1
+
+
+def test_upsert_portal_info_timestamps_are_naive_utc():
+    _clean()
+    rid = uuid.uuid4().hex.encode()
+    kq.upsert_portal_info(engine, rid, 'KPTEST_TS', 'T', 'md', '<p>b</p>')
+    got = kq.get_by_registry_dataset_id(engine, rid)
+    assert got['created_at'].tzinfo is None and got['updated_at'].tzinfo is None


### PR DESCRIPTION
## Summary

Phase 2 backend for KP dataset portal-display info: users author title/portals/experiment summary in the registry UI (companion data-registry PR) and the API composes the Drupal-pattern body server-side, writing to `kp_datasets` — replacing Drupal authoring for new datasets.

- `GET /api/kp-portals` — cached bioindex portal-groups proxy (authenticated)
- `dataregistry/api/kp_datasets_body.py` — `compose_body` (exact hand-authored Drupal `<h3>` section pattern, HTML-escaped) + `parse_experiment_summary` (round-trips form-generated bodies; migrated hand-authored bodies deliberately don't)
- `kp_datasets_query.upsert_portal_info` / `get_by_registry_dataset_id` — one KP row per registry dataset, adopt-unlinked-migrated-row semantics with BINARY (byte-exact) name matching
- `GET/POST /api/kp-dataset-info` — `check_perms`-gated; 422 (blank title / invalid portals / oversize), 404, IntegrityError→409; body composed from publication + per-file phenotype display names + summary
- Saved rows serve immediately via the public `/api/kpn/rest/views/datasetinfo` envelope (integration-tested end-to-end)

No schema change — no Alembic migration; deploy ordering unconstrained.

## Test plan

Full suite: **473 passed, 0 failed** (docker MySQL harness). New coverage: portals proxy + auth, compose/parse round-trip + escaping, upsert create/update/adopt/case-variant-conflict/naive-UTC, endpoint validation matrix, and POST→public-envelope integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qkb5thQHx1NSGBRGv9rdAb