### PR TITLE
Call bioindex via per-env origin hosts (Cloudflare challenges datacenter IPs)

### DIFF
--- a/dataregistry/api/config.py
+++ b/dataregistry/api/config.py
@@ -1,7 +1,20 @@
 import json
+import os
 from functools import lru_cache
 
 from boto3 import Session
+
+
+def bioindex_base_url() -> str:
+    """Server-side bioindex origin. The public bioindex.hugeamp.org sits behind
+    a Cloudflare bot challenge that 403s requests from datacenter IPs, so
+    server-to-server calls go to the environment's origin host directly.
+    Browser-side fetches keep using the public domain."""
+    override = os.environ.get('BIOINDEX_BASE_URL')
+    if override:
+        return override.rstrip('/')
+    env = 'prod' if os.environ.get('DATA_REGISTRY_DB_NAME') == 'dataregistry' else 'qa'
+    return f'http://bioindex-{env}.hugeampkpnbi.org/main'
 
 
 @lru_cache

--- a/dataregistry/api/phenotypes.py
+++ b/dataregistry/api/phenotypes.py
@@ -2,10 +2,12 @@ from functools import lru_cache
 
 import requests
 
+from dataregistry.api.config import bioindex_base_url
+
 
 @lru_cache
 def get_phenotypes() -> dict:
-    http_res = requests.get('https://bioindex.hugeamp.org/api/portal/phenotypes')
+    http_res = requests.get(f'{bioindex_base_url()}/api/portal/phenotypes', timeout=30)
     json = http_res.json()
     phenos = json['data']
     result = {pheno['name']: pheno for pheno in phenos}

--- a/dataregistry/api/portals.py
+++ b/dataregistry/api/portals.py
@@ -3,9 +3,11 @@ from functools import lru_cache
 
 import requests
 
+from dataregistry.api.config import bioindex_base_url
+
 
 @lru_cache
 def get_portals() -> list:
-    res = requests.get('https://bioindex.hugeamp.org/api/portal/groups', timeout=30)
+    res = requests.get(f'{bioindex_base_url()}/api/portal/groups', timeout=30)
     res.raise_for_status()
     return sorted(g['name'] for g in res.json()['data'])

--- a/tests/api/test_kp_dataset_info.py
+++ b/tests/api/test_kp_dataset_info.py
@@ -13,7 +13,7 @@ AUTH = {'Authorization': f"Bearer {get_encoded_jwt_data(User(user_name='test', r
 def test_kp_portals_lists_bioindex_groups():
     from dataregistry.api import portals
     portals.get_portals.cache_clear()
-    responses.get('https://bioindex.hugeamp.org/api/portal/groups',
+    responses.get('http://bioindex-qa.hugeampkpnbi.org/main/api/portal/groups',
                   json={'data': [{'name': 'md'}, {'name': 'a2f'}, {'name': 'cvd'}]})
     resp = client.get('/api/kp-portals', headers=AUTH)
     assert resp.status_code == 200
@@ -46,9 +46,9 @@ def _mock_bioindex():
     from dataregistry.api import portals, phenotypes
     portals.get_portals.cache_clear()
     phenotypes.get_phenotypes.cache_clear()
-    responses.get('https://bioindex.hugeamp.org/api/portal/groups',
+    responses.get('http://bioindex-qa.hugeampkpnbi.org/main/api/portal/groups',
                   json={'data': [{'name': 'md'}, {'name': 'a2f'}]})
-    responses.get('https://bioindex.hugeamp.org/api/portal/phenotypes',
+    responses.get('http://bioindex-qa.hugeampkpnbi.org/main/api/portal/phenotypes',
                   json={'data': [{'name': 'T2D', 'description': 'Type 2 diabetes',
                                   'dichotomous': True}]})
 


### PR DESCRIPTION
## Summary

QA manual testing surfaced `/api/kp-portals` returning 500: `bioindex.hugeamp.org` is behind a Cloudflare bot challenge (`cf-mitigated: challenge`) that 403s server-side requests from the registry EC2 host — confirmed from the box with any user-agent, on `portal/groups` AND `portal/phenotypes` (so the pre-existing `get_phenotypes()` phenotype-save path was latently broken too).

Server-to-server calls now target the per-environment origin directly: `http://bioindex-{qa|prod}.hugeampkpnbi.org/main` (env derived from `DATA_REGISTRY_DB_NAME`, overridable via `BIOINDEX_BASE_URL`). Both origins verified 200 from the registry box with identical response shapes. Browser-side fetches keep the public https domain — no mixed content.

## Test plan

`tests/api/ + tests/kpn_cms/`: 65 passed. Env resolution sanity-checked (default→qa, `dataregistry`→prod, override respected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qkb5thQHx1NSGBRGv9rdAb